### PR TITLE
Add dev server launch configuration

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Website (Vite dev)",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd website && bun run dev"],
+      "port": 5173
+    },
+    {
+      "name": "Website (preview built)",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd website && bun run preview"],
+      "port": 4173
+    }
+  ]
+}


### PR DESCRIPTION
- Add `.claude/launch.json` with launch configurations for the development environment
- Configure two launch profiles:
  - Website (Vite dev): Runs `bun run dev` in the website directory on port 5173
  - Website (preview built): Runs `bun run preview` in the website directory on port 4173
- Enables easy local development server startup