### PR TITLE
Add audit plan and cmux orchestrator

### DIFF
--- a/AUDIT_PLAN.md
+++ b/AUDIT_PLAN.md
@@ -1,0 +1,300 @@
+# gen-gen Audit — Execution Plan
+
+## Background
+
+Full audit of the gen-gen library. Issues identified:
+
+1. Config drift: project-level options exist in both the data-gen file AND the API/plugin/CLI
+2. Missing declarative surfaces: `fakerStrategy`, `propertyPolicy`, `deepMerge` unreachable from data-gen file
+3. Unnecessary features: `readonlyProperties: "warn"`, `typeMappingPresets`, `markerText`, `watchDiagnostics`
+4. API ergonomics: no type-safe override keys, no function-reference shorthand, no array count helper
+5. Bugs: block-body zero-arg arrow functions in FakerOverrides behave differently from expression-body ones
+6. Deep merge should always be on (or default true); no good reason to use shallow
+
+---
+
+## Dependency Graph
+
+```
+Batch A (fully independent — run all in parallel)
+├── T1:    Remove readonlyProperties option
+├── T2T3:  Remove markerText + move watchDiagnostics to env var
+├── T4T5:  FakerOverrides improvements (bugfix + shorthand syntax)
+├── T6:    Export GenGenConfigOptions static type
+├── T7:    Make deepMerge default true
+├── T8:    Plural array helpers in callbacks
+├── T9:    Improve unused override warning messages
+└── T14:   Generate FakerOverridePaths + TypedFakerOverrides types
+
+Batch B (after Batch A, independent of each other)
+├── T10:   Add GenGenConfig parsing in data-gen file
+└── T11:   Add FakerStrategy parsing in data-gen file
+
+Batch C (after Batch B)
+├── T12:   Strip project-specific options from API/CLI  ← needs T10 + T11
+└── T13:   Remove typeMappingPresets                    ← needs T11
+```
+
+All PRs target `main`. Each task gets its own worktree and changeset.
+
+---
+
+## Tasks
+
+### T1 — Remove `readonlyProperties` option
+
+**What:** The `"warn"` value adds no value for test data (readonly is TypeScript-only). Remove the option entirely; always include readonly fields silently.
+
+**Files:** `src/generator.ts`, `src/cli-core.ts`, `src/cli.ts`, `src/vite-plugin.ts`
+
+**Changes:**
+- Remove `readonlyProperties` from `PropertyPolicy` interface → collapse to just `optionalProperties` and `indexSignatures`
+- Remove CLI flag `--readonly-properties` and related parsing
+- Remove from `GenGenPluginOptions`, `CliOptions`, `GenerateOptions`
+- Remove from `resolvePropertyPolicy` and `DEFAULT_PROPERTY_POLICY`
+- Remove any generator code that checks `policy.readonlyProperties`
+- Update tests in `test/generator.test.ts`, `test/cli-core.test.ts`
+
+**Changeset:** `patch` — "Remove readonlyProperties policy option; readonly fields are always included silently"
+
+---
+
+### T2T3 — Remove `markerText` option + move `watchDiagnostics` to env var
+
+**T2 — markerText:** The default marker `"Generated below - DO NOT EDIT"` is universally fine. Customizing it adds dead API surface.
+
+**Files:** `src/generator.ts`, `src/vite-plugin.ts`
+
+**Changes:**
+- Remove `markerText` from `GenerateOptions` and `GenGenPluginOptions`
+- Inline `DEFAULT_MARKER_TEXT` constant directly in `generateDataFile`
+- Update tests
+
+**T3 — watchDiagnostics:** Internal dev tool for timing watch cycles — shouldn't be a public API option.
+
+**Files:** `src/vite-plugin.ts`, `src/cli-core.ts`, `src/cli.ts`
+
+**Changes:**
+- Remove `watchDiagnostics` from `GenGenPluginOptions` and `CliOptions`
+- Read from `process.env.GEN_GEN_WATCH_DIAGNOSTICS === "1"` instead
+- Update tests
+
+**Changeset:** `patch` — "Remove markerText option and move watchDiagnostics to GEN_GEN_WATCH_DIAGNOSTICS env var"
+
+---
+
+### T4T5 — FakerOverrides improvements (bugfix + shorthand syntax)
+
+**T4 — bugfix:** Zero-arg block-body arrow functions in FakerOverrides don't get body extraction, while expression-body ones do. `() => { return faker.internet.email(); }` stays as "call" mode while `() => faker.internet.email()` becomes "raw". Fix: also extract block-body single-return zero-arg arrows.
+
+**T5 — shorthand:** Allow bare function references as FakerOverrides values. `email: faker.internet.email` should emit `faker.internet.email()`. Currently falls through to raw mode emitting without calling (latent bug).
+
+**Files:** `src/generator.ts` — `extractFunctionOverrideSpec` function (lines ~427–474)
+
+**Changes for T4:** In the `isArrowFunction` branch with `parameters.length === 0`, when the body is a `Block` with a single return statement, extract its expression with `invokeMode: "raw"`.
+
+**Changes for T5:** Add before the final `return null`:
+```ts
+if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+  return {
+    expression: `${expression.getText(sourceFile)}()`,
+    invokeMode: "raw",
+  };
+}
+```
+
+**Tests:** Add fixture tests for both cases in `test/generator.test.ts`.
+
+**Changeset:** `minor` — "Support bare function references in FakerOverrides (e.g. `email: faker.internet.email`); fix block-body zero-arg arrow function handling"
+
+---
+
+### T6 — Export `GenGenConfigOptions` static type
+
+**What:** Export a static type for the `GenGenConfig` const users will add to their data-gen file. Also export `FakerStrategyContext` and `FakerStrategyResult` for annotating a `FakerStrategy` const.
+
+**Files:** `src/generator.ts`, `src/index.ts`
+
+**Changes:**
+```ts
+// src/generator.ts — add:
+export interface GenGenConfigOptions {
+  deepMerge?: boolean;
+  optionalProperties?: "include" | "omit";
+  indexSignatures?: "ignore" | "warn";
+}
+
+// src/index.ts — add re-exports:
+export type { GenGenConfigOptions, FakerStrategyContext, FakerStrategyResult } from "./generator.js";
+```
+
+Note: `FakerStrategyContext` and `FakerStrategyResult` are already defined in `generator.ts` but may need `export` added.
+
+**Changeset:** `minor` — "Export GenGenConfigOptions, FakerStrategyContext, and FakerStrategyResult types for data-gen file annotations"
+
+---
+
+### T7 — Make `deepMerge` default `true`
+
+**What:** No good reason to default to shallow merge. The `Object.assign` footgun drops sibling fields on nested overrides. When you need explicit replacement, callbacks handle it.
+
+**Files:** `src/generator.ts`, `src/cli-core.ts`
+
+**Changes:**
+- `generateDataFile`: change `options.deepMerge ?? false` → `options.deepMerge ?? true`
+- `parseArgs`: change `deepMerge: false` → `deepMerge: true` in default options
+- Update tests that rely on the old shallow-merge default
+
+**Changeset:** `major` — "Deep merge is now the default; pass deepMerge: false to opt out"
+
+---
+
+### T8 — Plural array helpers in callbacks
+
+**What:** Add `generateXxxItems(count, overrides?)` alongside existing `generateXxxItem(overrides?)`. Closes the gap between "fully specify an array" and "random-length array" — enables "N default items."
+
+**Files:** `src/generator.ts` — code emission for `GenGenHelpers` type and `__genGenCreateHelper`
+
+**Changes:**
+- In `GenGenHelpers<T>` generated type, add plural form for each array-item key:
+  ```ts
+  generateItemsItem: (overrides?: ...) => Item      // existing
+  generateItemsItems: (count: number, overrides?: ...) => Item[]  // new
+  ```
+- Emit the plural helper function in the runtime helper factory:
+  ```ts
+  generateItemsItems: (count: number, overrides?) =>
+    Array.from({ length: count }, () => generateItemsItem(overrides))
+  ```
+
+**Tests:** Add fixture tests demonstrating `generateXxxItems(n)` in callback.
+
+**Changeset:** `minor` — "Add plural array helpers to callback API: generateXxxItems(count, overrides?)"
+
+---
+
+### T9 — Improve unused override warning messages
+
+**What:** "Faker override key 'X' was not used" doesn't help the developer fix the issue. Add nearest-match suggestions.
+
+**Files:** `src/generator.ts` — `collectUnusedFakerOverrideWarnings` function
+
+**Changes:**
+- Pass the set of all matched override paths through to the warning collector
+- For each unused key, find the closest match (substring or Levenshtein distance)
+- Update warning format: `"Faker override key 'User.emial' was not used. Did you mean 'User.email'?"`
+
+**Changeset:** `patch` — "Improve unused FakerOverride key warnings with nearest-match suggestions"
+
+---
+
+### T10 — Add `GenGenConfig` parsing in data-gen file
+
+**What:** Allow `const GenGenConfig = { ... } as const` in the data-gen file to control `deepMerge`, `optionalProperties`, `indexSignatures`. Moves project config into the data-gen file.
+
+**Files:** `src/generator.ts`
+
+**Changes:**
+- Add `collectGenGenConfig(sourceFile): Partial<GenGenConfig>` function (pattern: find `VariableDeclaration` named `GenGenConfig`, unwrap `as const`, extract object literal properties as string/boolean values)
+- Call in `parseTargets`, return alongside other parsed values
+- In `generateDataFile`, merge: data-gen file config is the base, API-level options override (for CI use)
+
+**Tests:** Add fixture tests with `GenGenConfig` const and verify it changes generation behavior.
+
+**Changeset:** `minor` — "Add GenGenConfig declarative config in data-gen file (deepMerge, optionalProperties, indexSignatures)"
+
+---
+
+### T11 — Add `FakerStrategy` parsing in data-gen file
+
+**What:** Allow `const FakerStrategy = (ctx) => { ... }` in the data-gen file, making the strategy hook accessible without the programmatic API.
+
+**Files:** `src/generator.ts`
+
+**Changes:**
+- Add `collectFakerStrategy(sourceFile): FakerStrategyHook | undefined` function (find `VariableDeclaration` or `FunctionDeclaration` named `FakerStrategy`, extract function body text, eval it to get a callable hook)
+- In `parseTargets`, return the extracted strategy
+- In `generateDataFile`, merge with API-level `fakerStrategy` (API takes precedence)
+- The `FakerStrategyContext` type should already be importable from gen-gen (T6)
+
+**Tests:** Add fixture tests with `FakerStrategy` const and verify it affects generated expressions.
+
+**Changeset:** `minor` — "Add FakerStrategy declarative config in data-gen file"
+
+---
+
+### T12 — Strip project-specific options from API/CLI
+
+**What:** After T10 + T11 land, all project config is in the data-gen file. Remove it from the programmatic API surface.
+
+**Prerequisite:** T10 and T11 merged
+
+**Files:** `src/generator.ts`, `src/cli-core.ts`, `src/cli.ts`, `src/vite-plugin.ts`
+
+**Remove from API/CLI:**
+- `deepMerge` → GenGenConfig
+- `propertyPolicy` → GenGenConfig
+- `fakerStrategy` → FakerStrategy const in data-gen file
+- `fakerOverrides` → FakerOverrides const in data-gen file
+- `include` / `exclude` → IncludeGenerators / ExcludeGenerators in data-gen file
+
+**Keep (operational only):** `input`, `cwd`, `write`, `failOnWarn`, `watch`, `check`, `dryRun`
+
+**Changeset:** `major` — "Remove project-specific options from API/CLI; all project config now lives in the data-gen file"
+
+---
+
+### T13 — Remove `typeMappingPresets`
+
+**What:** Opaque built-in strategy rules. With declarative `FakerStrategy` available, they're unnecessary.
+
+**Prerequisite:** T11 merged
+
+**Files:** `src/generator.ts`, `src/cli-core.ts`, `src/cli.ts`, `src/vite-plugin.ts`
+
+**Changes:**
+- Remove `TypeMappingPresetName` type and all preset resolution/matching logic
+- Remove `--preset` CLI flag
+- Remove from all option interfaces
+- Update tests
+
+**Changeset:** `major` — "Remove typeMappingPresets; use FakerStrategy in your data-gen file instead"
+
+---
+
+### T14 — Generate `FakerOverridePaths` and `TypedFakerOverrides` types
+
+**What:** Generate a union type of all valid `RootType.property.path` keys plus a typed FakerOverrides map. Enables type-safe override keys with IDE autocomplete.
+
+**Files:** `src/generator.ts` — `emitFunctions` and property traversal
+
+**Changes:**
+- Collect all `"TypeName.prop.nested"` path strings during property traversal
+- Emit at top of generated section:
+  ```ts
+  export type FakerOverridePaths =
+    | "User.id"
+    | "User.email"
+    | "User.profile.name"
+    // ...
+
+  export type TypedFakerOverrides = {
+    [K in FakerOverridePaths | (string & {})]?: (...args: any[]) => unknown | string;
+  };
+  ```
+- Wide value type (`(...args: any[]) => unknown | string`) accepts both arrow functions and bare references (`faker.internet.email`)
+
+**Tests:** Add fixture tests verifying the generated union and map types are correct.
+
+**Changeset:** `minor` — "Generate FakerOverridePaths and TypedFakerOverrides utility types for type-safe override keys"
+
+---
+
+## Verification (all tasks)
+
+```bash
+bun run typecheck     # TypeScript strict check
+bun test              # Full test suite
+bun run gen:example   # Validate CLI with all examples
+bun run build         # Ensure dist/ builds clean
+```

--- a/scripts/orchestrate-audit.sh
+++ b/scripts/orchestrate-audit.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# orchestrate-audit.sh — runs all gen-gen audit tasks in parallel cmux workspaces
+#
+# Run this script from within a cmux terminal. It will:
+#   1. Open a workspace per task in Batch A (all parallel)
+#   2. Wait for all Batch A tasks to finish
+#   3. Open Batch B workspaces
+#   4. Wait, then open Batch C
+#
+# Each workspace runs claude autonomously. Progress is shown in this workspace's sidebar.
+#
+# Usage:
+#   bash scripts/orchestrate-audit.sh
+#
+# Requirements:
+#   - Run from within cmux (CMUX_WORKSPACE_ID must be set)
+#   - claude must be in PATH
+#   - gh must be in PATH and authenticated
+
+set -euo pipefail
+
+CMUX=/Applications/cmux.app/Contents/Resources/bin/cmux
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PLAN="$REPO/AUDIT_PLAN.md"
+RUN_DIR=$(mktemp -d /tmp/gen-gen-audit-XXXXXX)
+
+log() { echo "[orchestrator] $*"; }
+fail() { echo "[orchestrator] ERROR: $*" >&2; exit 1; }
+
+[ -f "$PLAN" ] || fail "AUDIT_PLAN.md not found at $REPO"
+[ -n "${CMUX_WORKSPACE_ID:-}" ] || fail "Not running inside cmux (CMUX_WORKSPACE_ID is not set)"
+command -v claude >/dev/null || fail "claude not found in PATH"
+command -v gh >/dev/null || fail "gh not found in PATH"
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+# Write a task runner script + prompt file, then open it in a new named workspace
+launch_task() {
+  local id=$1   # e.g. T1, T2T3
+  local title=$2
+  local prompt=$3
+
+  local prompt_file="$RUN_DIR/prompt_${id}.txt"
+  local runner="$RUN_DIR/run_${id}.sh"
+  local done_file="$RUN_DIR/${id}.done"
+  local fail_file="$RUN_DIR/${id}.fail"
+
+  printf '%s' "$prompt" > "$prompt_file"
+
+  cat > "$runner" << RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$REPO"
+echo "=== Task $id: $title ==="
+echo "Plan: $PLAN"
+echo ""
+claude --dangerously-skip-permissions -p "\$(cat "$prompt_file")"
+exit_code=\$?
+if [ "\$exit_code" -eq 0 ]; then
+  touch "$done_file"
+  $CMUX notify --title "✓ $id done" --body "$title" 2>/dev/null || true
+  $CMUX log --source "audit" -- "Task $id succeeded" 2>/dev/null || true
+else
+  touch "$fail_file"
+  $CMUX notify --title "✗ $id failed" --body "$title — check the workspace" 2>/dev/null || true
+  $CMUX log --level error --source "audit" -- "Task $id failed (exit \$exit_code)" 2>/dev/null || true
+fi
+RUNNER
+  chmod +x "$runner"
+
+  local ws_ref
+  ws_ref=$($CMUX new-workspace --cwd "$REPO" --command "bash $runner")
+  $CMUX rename-workspace --workspace "$ws_ref" "$id: $title" 2>/dev/null || true
+
+  log "Launched $id → workspace $ws_ref"
+}
+
+# Poll until all listed task IDs have a .done or .fail file
+wait_for() {
+  local tasks=("$@")
+  local pending=true
+  while $pending; do
+    pending=false
+    for id in "${tasks[@]}"; do
+      if [[ ! -f "$RUN_DIR/${id}.done" && ! -f "$RUN_DIR/${id}.fail" ]]; then
+        pending=true
+        break
+      fi
+    done
+    $pending && sleep 15
+  done
+}
+
+# Count done/fail across a list of task IDs
+count_results() {
+  local tasks=("$@")
+  local done=0 failed=0
+  for id in "${tasks[@]}"; do
+    [[ -f "$RUN_DIR/${id}.done" ]] && ((done++)) || true
+    [[ -f "$RUN_DIR/${id}.fail" ]] && ((failed++)) || true
+  done
+  echo "done=$done failed=$failed"
+}
+
+status() {
+  $CMUX set-status "audit" "$1" 2>/dev/null || true
+  log "$1"
+}
+
+progress() {
+  $CMUX set-progress "$1" --label "$2" 2>/dev/null || true
+}
+
+# ─── task prompts ─────────────────────────────────────────────────────────────
+# Each prompt is self-contained: reference the plan, state the task, give steps.
+
+BASE_INSTRUCTIONS="Read the execution plan at $PLAN and implement the task described below.
+
+Use EnterWorktree to create a new isolated worktree from the main branch.
+Implement all changes described for this task in the plan.
+Run the verification: bun run typecheck && bun test && bun run build && bun run gen:example
+Create a changeset file in .changeset/ using the bump type and message from the plan.
+Commit all changes with a clear commit message and open a PR to main.
+Exit the worktree when done."
+
+PROMPT_T1="$BASE_INSTRUCTIONS
+
+Task: T1 — Remove the readonlyProperties option from the PropertyPolicy interface and all related code."
+
+PROMPT_T2T3="$BASE_INSTRUCTIONS
+
+Task: T2T3 — Remove the markerText option AND move watchDiagnostics behind the GEN_GEN_WATCH_DIAGNOSTICS env var. Both are in the same PR."
+
+PROMPT_T4T5="$BASE_INSTRUCTIONS
+
+Task: T4T5 — Two FakerOverrides fixes in one PR:
+(T4) Fix block-body zero-arg arrow functions to get body extraction same as expression-body ones.
+(T5) Support bare function references like 'email: faker.internet.email' (auto-call via PropertyAccessExpression detection in extractFunctionOverrideSpec)."
+
+PROMPT_T6="$BASE_INSTRUCTIONS
+
+Task: T6 — Export GenGenConfigOptions interface, and also ensure FakerStrategyContext and FakerStrategyResult are re-exported from src/index.ts."
+
+PROMPT_T7="$BASE_INSTRUCTIONS
+
+Task: T7 — Change the deepMerge default from false to true in both generateDataFile (generator.ts) and parseArgs (cli-core.ts). Update any tests that relied on the old shallow-merge default."
+
+PROMPT_T8="$BASE_INSTRUCTIONS
+
+Task: T8 — Add plural array helper generateXxxItems(count, overrides?) alongside each existing generateXxxItem(overrides?) helper in the GenGenHelpers type and runtime factory."
+
+PROMPT_T9="$BASE_INSTRUCTIONS
+
+Task: T9 — Improve unused FakerOverride key warnings to suggest the nearest valid path (e.g. 'Did you mean User.email?') using fuzzy/substring matching against the set of known matched paths."
+
+PROMPT_T14="$BASE_INSTRUCTIONS
+
+Task: T14 — Generate FakerOverridePaths union type and TypedFakerOverrides mapped type into the generated section of each data-gen file."
+
+PROMPT_T10="$BASE_INSTRUCTIONS
+
+Task: T10 — Add collectGenGenConfig() to parse a 'const GenGenConfig = { ... } as const' declaration from the data-gen file, and merge it into generation options (data-gen file config as base, API options override)."
+
+PROMPT_T11="$BASE_INSTRUCTIONS
+
+Task: T11 — Add collectFakerStrategy() to parse a 'const FakerStrategy = (ctx) => { ... }' declaration from the data-gen file, extract the function via AST, eval it, and use it as the strategy hook."
+
+PROMPT_T12="$BASE_INSTRUCTIONS
+
+Task: T12 — Strip project-specific options from GenerateOptions, GenGenPluginOptions, and CLI. Keep only: input, cwd, write, failOnWarn, watch, check, dryRun. Prerequisite: T10 and T11 must already be merged."
+
+PROMPT_T13="$BASE_INSTRUCTIONS
+
+Task: T13 — Remove typeMappingPresets entirely: the TypeMappingPresetName type, all preset resolution logic, the --preset CLI flag, and all related interfaces. Prerequisite: T11 must already be merged."
+
+# ─── main ─────────────────────────────────────────────────────────────────────
+
+log "Run directory: $RUN_DIR"
+log "Repo: $REPO"
+echo ""
+
+# ── Batch A ──────────────────────────────────────────────────────────────────
+status "Batch A: launching 8 tasks in parallel"
+progress 0.05 "Batch A starting..."
+
+launch_task "T1"   "Remove readonlyProperties"         "$PROMPT_T1"
+launch_task "T2T3" "markerText + watchDiagnostics"     "$PROMPT_T2T3"
+launch_task "T4T5" "FakerOverrides improvements"       "$PROMPT_T4T5"
+launch_task "T6"   "Export GenGenConfigOptions"        "$PROMPT_T6"
+launch_task "T7"   "deepMerge default true"            "$PROMPT_T7"
+launch_task "T8"   "Plural array helpers"              "$PROMPT_T8"
+launch_task "T9"   "Warning improvements"              "$PROMPT_T9"
+launch_task "T14"  "FakerOverridePaths types"          "$PROMPT_T14"
+
+log "All Batch A tasks launched. Waiting for completion..."
+progress 0.1 "Batch A running (8 tasks)..."
+
+BATCH_A=(T1 T2T3 T4T5 T6 T7 T8 T9 T14)
+wait_for "${BATCH_A[@]}"
+
+read -r results <<< "$(count_results "${BATCH_A[@]}")"
+log "Batch A complete — $results"
+$CMUX notify --title "Batch A complete" --body "$results — starting Batch B" 2>/dev/null || true
+progress 0.55 "Batch B starting..."
+
+# ── Batch B ──────────────────────────────────────────────────────────────────
+status "Batch B: launching T10 + T11"
+
+launch_task "T10" "GenGenConfig parsing"    "$PROMPT_T10"
+launch_task "T11" "FakerStrategy parsing"   "$PROMPT_T11"
+
+log "Batch B tasks launched. Waiting..."
+progress 0.6 "Batch B running (2 tasks)..."
+
+BATCH_B=(T10 T11)
+wait_for "${BATCH_B[@]}"
+
+read -r results <<< "$(count_results "${BATCH_B[@]}")"
+log "Batch B complete — $results"
+$CMUX notify --title "Batch B complete" --body "$results — starting Batch C" 2>/dev/null || true
+progress 0.8 "Batch C starting..."
+
+# ── Batch C ──────────────────────────────────────────────────────────────────
+status "Batch C: launching T12 + T13 (requires T10+T11 merged — confirm before continuing)"
+
+echo ""
+echo "⚠  Batch C depends on T10 and T11 being MERGED (not just open)."
+echo "   Have you merged both Batch B PRs? [y/N]"
+read -r confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+  echo "Aborting Batch C. Re-run the script from the Batch C section when ready."
+  $CMUX clear-progress 2>/dev/null || true
+  exit 0
+fi
+
+launch_task "T12" "Strip API/CLI options"       "$PROMPT_T12"
+launch_task "T13" "Remove typeMappingPresets"   "$PROMPT_T13"
+
+log "Batch C tasks launched. Waiting..."
+progress 0.85 "Batch C running (2 tasks)..."
+
+BATCH_C=(T12 T13)
+wait_for "${BATCH_C[@]}"
+
+read -r results <<< "$(count_results "${BATCH_C[@]}")"
+log "Batch C complete — $results"
+
+progress 1.0 "All done!"
+$CMUX notify --title "Audit complete" --body "All tasks finished. Check PRs on GitHub." 2>/dev/null || true
+$CMUX clear-progress 2>/dev/null || true
+
+echo ""
+echo "=== All tasks complete ==="
+echo "Run dir (logs/sentinels): $RUN_DIR"
+echo "Check GitHub for open PRs: gh pr list"


### PR DESCRIPTION
## Summary

- Adds `AUDIT_PLAN.md` documenting a full library audit with 14 improvement tasks organized into dependency-ordered batches (A → B → C)
- Adds `scripts/orchestrate-audit.sh` — a cmux-powered orchestrator that opens one workspace per task and runs Claude autonomously, using sentinel files to sequence dependent batches

## Audit findings covered

- Config drift between the data-gen file and API/plugin/CLI options
- Missing declarative surfaces (`fakerStrategy`, `propertyPolicy`, `deepMerge`)
- Unnecessary API surface (`readonlyProperties: "warn"`, `typeMappingPresets`, `markerText`, `watchDiagnostics`)
- Ergonomics gaps (no type-safe override keys, no function-reference shorthand, no array count helper)
- Bug: block-body vs expression-body arrow function parity in `FakerOverrides`
- Deep merge should default to `true`

## Test plan

- [ ] Review `AUDIT_PLAN.md` task descriptions for accuracy
- [ ] Run `bash scripts/orchestrate-audit.sh` from inside a cmux terminal to kick off autonomous implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)