### PR TITLE
Scope claude permissions and remove dangerously-skip-permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git checkout *)",
+      "Bash(git switch *)",
+      "Bash(git status)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git branch *)",
+      "Bash(git worktree *)",
+      "Bash(gh pr create *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(node *)",
+      "Bash(npx *)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(rm -rf *)",
+      "Bash(gh pr merge *)"
+    ]
+  }
+}

--- a/scripts/orchestrate-audit.sh
+++ b/scripts/orchestrate-audit.sh
@@ -55,7 +55,7 @@ cd "$REPO"
 echo "=== Task $id: $title ==="
 echo "Plan: $PLAN"
 echo ""
-claude --dangerously-skip-permissions -p "\$(cat "$prompt_file")"
+claude -p "\$(cat "$prompt_file")"
 exit_code=\$?
 if [ "\$exit_code" -eq 0 ]; then
   touch "$done_file"


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with an explicit allow/deny list for tool permissions, replacing the blanket `--dangerously-skip-permissions` flag in the orchestrator
- Updates `scripts/orchestrate-audit.sh` to drop `--dangerously-skip-permissions`

## Permissions

**Allowed (auto-approved):** `bun *`, `git add/commit/push/checkout/switch/status/log/diff/branch/worktree`, `gh pr create/view/list`, `node/npx`

**Denied (always blocked):** `git push --force`, `git reset --hard`, `git clean -f`, `rm -rf`, `gh pr merge`

Anything outside these lists still prompts for approval.

## Test plan

- [ ] Run the orchestrator and confirm claude auto-approves allowed commands without prompting
- [ ] Confirm force-push and reset --hard are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)