### PR TITLE
T8: Add plural array helpers generateXxxItems(count, overrides?)

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -697,6 +697,7 @@ function emitObjectLiteral(
     }
 
     const declaration = property.valueDeclaration ?? property.declarations?.[0] ?? context.sourceFile;
+
     if (hasGenGenIgnoreTag(declaration, context.sourceFile)) {
       const propertyName = needsQuotedProperty(property.name) ? JSON.stringify(property.name) : property.name;
       const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
@@ -757,6 +758,13 @@ function emitSharedHelperRuntime(deepMerge: boolean): string {
     "    : `generate${Capitalize<string & K>}Item`]: (",
     "      overrides?: GenGenOverrides<__GenGenArrayItemPlainObject<NonNullable<T[K]>>>,",
     "    ) => __GenGenArrayItemPlainObject<NonNullable<T[K]>>;",
+    "} & {",
+    "  [K in keyof T as __GenGenArrayItemPlainObject<NonNullable<T[K]>> extends never",
+    "    ? never",
+    "    : `generate${Capitalize<string & K>}Items`]: (",
+    "      count: number,",
+    "      overrides?: GenGenOverrides<__GenGenArrayItemPlainObject<NonNullable<T[K]>>>,",
+    "    ) => __GenGenArrayItemPlainObject<NonNullable<T[K]>>[];",
     "};",
     "",
     "type GenGenOverrides<T extends object> = Partial<T> | ((helpers: GenGenHelpers<T>) => Partial<T>);",
@@ -806,6 +814,9 @@ function emitSharedHelperRuntime(deepMerge: boolean): string {
     "          if (firstMergeableItem) {",
     "            const arrayItemHelperName = `generate${key[0]?.toUpperCase() ?? \"\"}${key.slice(1)}Item`;",
     "            (helpers as Record<string, unknown>)[arrayItemHelperName] = __genGenCreateHelper(firstMergeableItem, helperCache);",
+    "            const arrayItemsHelperName = `generate${key[0]?.toUpperCase() ?? \"\"}${key.slice(1)}Items`;",
+    "            (helpers as Record<string, unknown>)[arrayItemsHelperName] = (count: number, overrides?: GenGenOverrides<typeof firstMergeableItem>) =>",
+    "              Array.from({ length: count }, () => (__genGenCreateHelper(firstMergeableItem, helperCache))(overrides));",
     "          }",
     "        }",
     "",

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -928,6 +928,50 @@ import type { Cart } from "./types";
     expect(value.items[0]?.sku).toEqual(expect.any(String));
   });
 
+  test("supports plural array-item helpers generateXxxItems(count, overrides?)", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type BlogPost = {
+  tags: {
+    name: string;
+    slug: string;
+  }[];
+};
+`,
+      "data-gen.ts": `
+import type { BlogPost } from "./types";
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: true});
+    expect(result.content).toContain("generate${Capitalize<string & K>}Items");
+    expect(result.content).toContain("arrayItemsHelperName");
+
+    const moduleUrl = `${pathToFileURL(path.join(cwd, "data-gen.ts")).href}?t=${Date.now()}`;
+    const generatedModule = (await import(moduleUrl)) as {
+      generateBlogPost(
+        overrides?: (helpers: {
+          generateTagsItem: (overrides?: {name?: string; slug?: string}) => {name: string; slug: string};
+          generateTagsItems: (count: number, overrides?: {name?: string; slug?: string}) => {name: string; slug: string}[];
+        }) => {
+          tags?: Array<{name: string; slug: string}>;
+        },
+      ): {tags: Array<{name: string; slug: string}>};
+    };
+
+    const value = generatedModule.generateBlogPost(({generateTagsItems}) => ({
+      tags: generateTagsItems(3),
+    }));
+
+    expect(value.tags).toHaveLength(3);
+    expect(value.tags[0]?.name).toEqual(expect.any(String));
+    expect(value.tags[0]?.slug).toEqual(expect.any(String));
+  });
+
   test("generates mixed unions by sampling across all concrete members", async () => {
     const cwd = await createFixture({
       "types.ts": `


### PR DESCRIPTION
## Summary
- Adds `generateXxxItems(count, overrides?)` plural helpers alongside existing `generateXxxItem(overrides?)` singular helpers
- Enables generating exactly N items: `generateTagsItems(3)` returns `Tag[]` of length 3

## Changes
- `src/generator.ts`: Emit plural helper in both the `GenGenHelpers` type and the runtime factory
- `test/generator.test.ts`: Add fixture tests (46 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)