### PR TITLE
T4T5: Fix FakerOverrides block-body arrows and add bare function reference support

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -436,6 +436,19 @@ function extractFunctionOverrideSpec(
           invokeMode: "raw",
         };
       }
+      if (ts.isBlock(expression.body)) {
+        const statements = expression.body.statements;
+        const firstStatement = statements[0];
+        if (statements.length === 1 && firstStatement && ts.isReturnStatement(firstStatement)) {
+          const returnExpr = firstStatement.expression;
+          if (returnExpr) {
+            return {
+              expression: returnExpr.getText(sourceFile),
+              invokeMode: "raw",
+            };
+          }
+        }
+      }
       if (ts.isExpression(expression.body)) {
         return {
           expression: expression.body.getText(sourceFile),
@@ -467,6 +480,13 @@ function extractFunctionOverrideSpec(
     return {
       expression: expression.getText(sourceFile),
       invokeMode: expression.parameters.length > 0 ? "callWithFaker" : "call",
+    };
+  }
+
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    return {
+      expression: `${expression.getText(sourceFile)}()`,
+      invokeMode: "raw",
     };
   }
 

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -509,6 +509,56 @@ import type { User } from "./types";
     expect(result.content).not.toContain("id: faker.string.uuid()");
   });
 
+  test("handles block-body zero-arg arrow functions in FakerOverrides same as expression-body", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type User = {
+  email: string;
+};
+`,
+      "data-gen.ts": `
+import type { User } from "./types";
+
+const FakerOverrides = {
+  email: () => { return faker.internet.email(); },
+} as const;
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("email: faker.internet.email()");
+  });
+
+  test("handles bare function references in FakerOverrides by calling them", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type User = {
+  email: string;
+};
+`,
+      "data-gen.ts": `
+import type { User } from "./types";
+
+const FakerOverrides = {
+  email: faker.internet.email,
+} as const;
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("email: faker.internet.email()");
+  });
+
   test("applies common preset mappings when enabled", async () => {
     const cwd = await createFixture({
       "types.ts": `


### PR DESCRIPTION
## Summary
- Fixes block-body zero-arg arrow functions (`() => { return x; }`) not being treated as raw expressions
- Adds support for bare function references (`email: faker.internet.email`) — now emits as `faker.internet.email()`

## Changes
- `src/generator.ts`: Update `extractFunctionOverrideSpec` to handle both cases; fix TypeScript type guard on `statements[0]`
- `test/generator.test.ts`: Add fixture tests for both new behaviors (47 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)