### PR TITLE
T14: Generate FakerOverridePaths and TypedFakerOverrides types

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -79,6 +79,7 @@ interface GenerationContext {
   typeTextCache: WeakMap<ts.Type, string>;
   propertiesCache: WeakMap<ts.Type, ts.Symbol[]>;
   enumValuesCache: WeakMap<ts.Type, string[] | null>;
+  collectedPaths: Set<string>;
 }
 
 const DEFAULT_INPUT = "data-gen.ts";
@@ -645,15 +646,48 @@ function emitFunctions(
     typeTextCache: new WeakMap(),
     propertiesCache: new WeakMap(),
     enumValuesCache: new WeakMap(),
+    collectedPaths: new Set<string>(),
   };
 
   const sections: string[] = [emitSharedHelperRuntime(deepMerge)];
   sections.push(...targets.map((target) => emitFunction(target, context)));
+
+  const overridePathsType = emitFakerOverridePaths(context.collectedPaths);
+
   return {
-    content: sections.join("\n\n"),
+    content: [overridePathsType, ...sections].join("\n\n"),
     usedFakerOverrideKeys: context.usedFakerOverrideKeys,
     warnings: [...context.emittedWarnings],
   };
+}
+
+function emitFakerOverridePaths(paths: Set<string>): string {
+  const sorted = [...paths].sort();
+
+  if (sorted.length === 0) {
+    return [
+      "export type FakerOverridePaths = never;",
+      "",
+      "export type TypedFakerOverrides = {",
+      "  [K in FakerOverridePaths | (string & {})]?: ((...args: any[]) => unknown) | string;",
+      "};",
+    ].join("\n");
+  }
+
+  const unionLines = sorted.map((p, i) => {
+    const prefix = i === 0 ? "  | " : "  | ";
+    return `${prefix}${JSON.stringify(p)}`;
+  });
+
+  return [
+    "export type FakerOverridePaths =",
+    ...unionLines,
+    ";",
+    "",
+    "export type TypedFakerOverrides = {",
+    "  [K in FakerOverridePaths | (string & {})]?: ((...args: any[]) => unknown) | string;",
+    "};",
+  ].join("\n");
 }
 
 function emitFunction(target: TargetSpec, context: GenerationContext): string {
@@ -841,6 +875,11 @@ function emitExpression(
 ): string {
   const checker = context.checker;
   const normalizedTypeText = getTypeText(type, context);
+
+  // Collect path for FakerOverridePaths type generation
+  if (propertyPath.length > 0) {
+    context.collectedPaths.add(`${rootTypeText}.${propertyPath.join(".")}`);
+  }
 
   const override = resolveFakerOverride(context, {
     rootTypeText,

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -951,4 +951,80 @@ import type { Mixed } from "./types";
     expect(result.content).toContain("faker.number.int({ min: 1, max: 1000 })");
     expect(result.content).toContain("code: faker.word.noun()");
   });
+
+  test("emits FakerOverridePaths union type with all valid path keys", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type User = {
+  id: string;
+  name: string;
+  profile: {
+    locale: string;
+  };
+};
+`,
+      "data-gen.ts": `
+import type { User } from "./types";
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("export type FakerOverridePaths =");
+    expect(result.content).toContain('"User.id"');
+    expect(result.content).toContain('"User.name"');
+    expect(result.content).toContain('"User.profile"');
+    expect(result.content).toContain('"User.profile.locale"');
+  });
+
+  test("emits TypedFakerOverrides mapped type referencing FakerOverridePaths", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type Item = {
+  label: string;
+  count: number;
+};
+`,
+      "data-gen.ts": `
+import type { Item } from "./types";
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("export type TypedFakerOverrides =");
+    expect(result.content).toContain("[K in FakerOverridePaths | (string & {})]?");
+    expect(result.content).toContain("((...args: any[]) => unknown) | string");
+  });
+
+  test("FakerOverridePaths includes paths for multiple types", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type Post = { title: string; body: string };
+export type Comment = { text: string; rating: number };
+`,
+      "data-gen.ts": `
+import type { Post, Comment } from "./types";
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain('"Post.title"');
+    expect(result.content).toContain('"Post.body"');
+    expect(result.content).toContain('"Comment.text"');
+    expect(result.content).toContain('"Comment.rating"');
+  });
 });


### PR DESCRIPTION
## Summary
- Generated section now includes `FakerOverridePaths` union type of all valid override key paths
- Generated section includes `TypedFakerOverrides` mapped type using `FakerOverridePaths`
- Enables type-safe FakerOverrides with IDE autocomplete for path keys

## Changes
- `src/generator.ts`: Collect paths during traversal via `collectedPaths` in `GenerationContext`, emit `FakerOverridePaths` and `TypedFakerOverrides` in generated section
- `test/generator.test.ts`: Add fixture tests verifying the generated types (48 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)