### PR TITLE
T11: Add FakerStrategy declarative config in data-gen file

### DIFF
--- a/packages/gen-gen/src/generator.ts
+++ b/packages/gen-gen/src/generator.ts
@@ -105,13 +105,14 @@ export async function generateDataFile(options: GenerateOptions = {}): Promise<G
     exclude: options.exclude ?? [],
     fakerOverrides: options.fakerOverrides ?? {},
   });
+  const fakerStrategy = options.fakerStrategy ?? parsed.fakerStrategy;
   const emitted = emitFunctions(
     parsed.targets,
     parsed.checker,
     parsed.sourceFile,
     options.deepMerge ?? true,
     parsed.fakerOverrides,
-    options.fakerStrategy,
+    fakerStrategy,
     options.typeMappingPresets ?? [],
     resolvePropertyPolicy(options.propertyPolicy),
   );
@@ -166,6 +167,7 @@ function parseTargets(
   warnings: string[];
   watchedFiles: string[];
   fakerOverrides: Map<string, FakerOverrideSpec>;
+  fakerStrategy: FakerStrategyHook | undefined;
 } {
   const compilerOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ESNext,
@@ -234,6 +236,8 @@ function parseTargets(
     .map((file) => path.resolve(file.fileName))
     .filter((fileName) => !fileName.includes("/node_modules/") && !fileName.endsWith(".d.ts"));
 
+  const fakerStrategy = collectFakerStrategy(sourceFile);
+
   return {
     sourceFile,
     checker,
@@ -241,6 +245,7 @@ function parseTargets(
     warnings,
     watchedFiles,
     fakerOverrides,
+    fakerStrategy,
   };
 }
 
@@ -389,6 +394,43 @@ function collectFakerOverrides(sourceFile: ts.SourceFile, warnings: string[]): R
   }
 
   return overrides;
+}
+
+function collectFakerStrategy(sourceFile: ts.SourceFile): FakerStrategyHook | undefined {
+  for (const statement of sourceFile.statements) {
+    let funcText: string | undefined;
+
+    // Handle: const FakerStrategy = (ctx) => { ... }
+    if (ts.isVariableStatement(statement)) {
+      const decl = statement.declarationList.declarations[0];
+      if (
+        decl &&
+        ts.isIdentifier(decl.name) &&
+        decl.name.text === "FakerStrategy" &&
+        decl.initializer
+      ) {
+        funcText = decl.initializer.getText(sourceFile);
+      }
+    }
+
+    // Handle: function FakerStrategy(ctx) { ... }
+    if (ts.isFunctionDeclaration(statement) && statement.name?.text === "FakerStrategy") {
+      funcText = statement.getText(sourceFile);
+      // Convert to expression form for eval
+      funcText = funcText.replace(/^function\s+FakerStrategy/, "function");
+    }
+
+    if (funcText) {
+      try {
+        // eslint-disable-next-line no-eval
+        const fn = eval(`(${funcText})`);
+        if (typeof fn === "function") return fn as FakerStrategyHook;
+      } catch {
+        // ignore eval errors
+      }
+    }
+  }
+  return undefined;
 }
 
 function unwrapObjectLiteralExpression(expression: ts.Expression): ts.ObjectLiteralExpression | undefined {

--- a/packages/gen-gen/test/generator.test.ts
+++ b/packages/gen-gen/test/generator.test.ts
@@ -1182,4 +1182,79 @@ import type { Post, Comment } from "./types";
     expect(result.content).toContain('"Comment.text"');
     expect(result.content).toContain('"Comment.rating"');
   });
+
+  test("applies FakerStrategy declared in source file as arrow function", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type User = {
+  id: string;
+  email: string;
+  age: number;
+};
+`,
+      "data-gen.ts": `
+import type { User } from "./types";
+
+const FakerStrategy = (ctx) => {
+  if (ctx.rootTypeText === "User" && ctx.path === "id") {
+    return { expression: "faker.string.uuid()", invokeMode: "raw" };
+  }
+  if (ctx.path === "email") {
+    return { expression: "faker.internet.email()", invokeMode: "raw" };
+  }
+  return undefined;
+};
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("id: faker.string.uuid()");
+    expect(result.content).toContain("email: faker.internet.email()");
+    expect(result.content).toContain("age: faker.number.int({ min: 1, max: 1000 })");
+  });
+
+  test("API-level fakerStrategy overrides file-level FakerStrategy", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type User = {
+  id: string;
+  email: string;
+};
+`,
+      "data-gen.ts": `
+import type { User } from "./types";
+
+const FakerStrategy = (ctx) => {
+  if (ctx.path === "id") {
+    return { expression: "faker.string.uuid()", invokeMode: "raw" };
+  }
+  return undefined;
+};
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({
+      cwd,
+      write: false,
+      fakerStrategy(context) {
+        if (context.path === "id") {
+          return {expression: "faker.string.alphanumeric(12)", invokeMode: "raw"};
+        }
+        return undefined;
+      },
+    });
+
+    // API strategy wins: alphanumeric, not uuid
+    expect(result.content).toContain("id: faker.string.alphanumeric(12)");
+    expect(result.content).not.toContain("id: faker.string.uuid()");
+  });
 });


### PR DESCRIPTION
## Summary
- Allows `const FakerStrategy = (ctx) => { ... }` in the data-gen file to hook into faker value generation
- API-level `fakerStrategy` still takes precedence (for programmatic overrides)
- Makes the strategy hook accessible without the programmatic API

## Changes
- `packages/gen-gen/src/generator.ts`: Add `collectFakerStrategy()`, call from `parseTargets`, merge in `generateDataFile`
- `packages/gen-gen/test/generator.test.ts`: Add fixture tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)