### PR TITLE
T10: Add GenGenConfig declarative config in data-gen file

### DIFF
--- a/packages/gen-gen/src/generator.ts
+++ b/packages/gen-gen/src/generator.ts
@@ -105,16 +105,22 @@ export async function generateDataFile(options: GenerateOptions = {}): Promise<G
     exclude: options.exclude ?? [],
     fakerOverrides: options.fakerOverrides ?? {},
   });
+  const fileConfig = parsed.genGenConfig;
+  const mergedDeepMerge = options.deepMerge ?? fileConfig.deepMerge ?? true;
+  const mergedPropertyPolicy = resolvePropertyPolicy({
+    ...fileConfig,
+    ...options.propertyPolicy,
+  });
   const fakerStrategy = options.fakerStrategy ?? parsed.fakerStrategy;
   const emitted = emitFunctions(
     parsed.targets,
     parsed.checker,
     parsed.sourceFile,
-    options.deepMerge ?? true,
+    mergedDeepMerge,
     parsed.fakerOverrides,
     fakerStrategy,
     options.typeMappingPresets ?? [],
-    resolvePropertyPolicy(options.propertyPolicy),
+    mergedPropertyPolicy,
   );
   const warnings = [
     ...parsed.warnings,
@@ -168,6 +174,7 @@ function parseTargets(
   watchedFiles: string[];
   fakerOverrides: Map<string, FakerOverrideSpec>;
   fakerStrategy: FakerStrategyHook | undefined;
+  genGenConfig: Partial<GenGenConfigOptions>;
 } {
   const compilerOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ESNext,
@@ -237,6 +244,7 @@ function parseTargets(
     .filter((fileName) => !fileName.includes("/node_modules/") && !fileName.endsWith(".d.ts"));
 
   const fakerStrategy = collectFakerStrategy(sourceFile);
+  const genGenConfig = collectGenGenConfig(sourceFile);
 
   return {
     sourceFile,
@@ -246,7 +254,44 @@ function parseTargets(
     watchedFiles,
     fakerOverrides,
     fakerStrategy,
+    genGenConfig,
   };
+}
+
+function collectGenGenConfig(sourceFile: ts.SourceFile): Partial<GenGenConfigOptions> {
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isVariableStatement(statement) &&
+      statement.declarationList.declarations.length === 1
+    ) {
+      const decl = statement.declarationList.declarations[0]!;
+      if (
+        ts.isIdentifier(decl.name) &&
+        decl.name.text === "GenGenConfig" &&
+        decl.initializer
+      ) {
+        // Unwrap `as const` if present
+        let init = decl.initializer;
+        if (ts.isAsExpression(init)) init = init.expression;
+
+        if (ts.isObjectLiteralExpression(init)) {
+          const config: Partial<GenGenConfigOptions> = {};
+          for (const prop of init.properties) {
+            if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+            const key = prop.name.text;
+            const val = prop.initializer;
+            if (key === "deepMerge" && (val.kind === ts.SyntaxKind.TrueKeyword || val.kind === ts.SyntaxKind.FalseKeyword)) {
+              config.deepMerge = val.kind === ts.SyntaxKind.TrueKeyword;
+            } else if ((key === "optionalProperties" || key === "indexSignatures") && ts.isStringLiteral(val)) {
+              (config as Record<string, unknown>)[key] = val.text;
+            }
+          }
+          return config;
+        }
+      }
+    }
+  }
+  return {};
 }
 
 function collectImportedTargets(

--- a/packages/gen-gen/test/generator.test.ts
+++ b/packages/gen-gen/test/generator.test.ts
@@ -1257,4 +1257,109 @@ const FakerStrategy = (ctx) => {
     expect(result.content).toContain("id: faker.string.alphanumeric(12)");
     expect(result.content).not.toContain("id: faker.string.uuid()");
   });
+
+  test("GenGenConfig in data-gen file sets optionalProperties to omit", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type Item = { id: number; name: string; description?: string };
+`,
+      "data-gen.ts": `
+import type { Item } from "./types";
+
+const GenGenConfig = {
+  optionalProperties: "omit",
+} as const;
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("export function generateItem(");
+    expect(result.content).toContain("id:");
+    expect(result.content).toContain("name:");
+    expect(result.content).not.toContain("description:");
+  });
+
+  test("GenGenConfig in data-gen file sets deepMerge to false", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type Nested = { a: string; b: { c: number } };
+`,
+      "data-gen.ts": `
+import type { Nested } from "./types";
+
+const GenGenConfig = {
+  deepMerge: false,
+} as const;
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("export function generateNested(");
+    // When deepMerge is false, the generator uses shallow spread instead of __genGenMergeDeep
+    expect(result.content).toContain("return { ...base, ...resolvedOverrides };");
+    expect(result.content).not.toContain("return __genGenMergeDeep(base, resolvedOverrides);");
+  });
+
+  test("API-level options override GenGenConfig in data-gen file", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type Item = { id: number; name: string; description?: string };
+`,
+      "data-gen.ts": `
+import type { Item } from "./types";
+
+const GenGenConfig = {
+  optionalProperties: "omit",
+} as const;
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    // API-level override: include optional properties despite file config saying omit
+    const result = await generateDataFile({
+      cwd,
+      write: false,
+      propertyPolicy: {optionalProperties: "include"},
+    });
+
+    expect(result.content).toContain("export function generateItem(");
+    expect(result.content).toContain("description:");
+  });
+
+  test("GenGenConfig deepMerge=true from file enables deep merge helper", async () => {
+    const cwd = await createFixture({
+      "types.ts": `
+export type Nested = { a: string; b: { c: number } };
+`,
+      "data-gen.ts": `
+import type { Nested } from "./types";
+
+const GenGenConfig = {
+  deepMerge: true,
+} as const;
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+`,
+    });
+
+    const result = await generateDataFile({cwd, write: false});
+
+    expect(result.content).toContain("function __genGenMergeDeep<T>(base: T, overrides: Partial<T> | undefined): T {");
+    expect(result.content).toContain("return __genGenMergeDeep(base, resolvedOverrides);")
+  });
 });


### PR DESCRIPTION
## Summary
- Allows `const GenGenConfig = { ... } as const` in the data-gen file to configure `deepMerge`, `optionalProperties`, `indexSignatures`
- Data-gen file config is the base; API-level options still override (for CI use)
- Moves project config out of the programmatic API and into the data-gen file

## Changes
- `packages/gen-gen/src/generator.ts`: Add `collectGenGenConfig()`, call from `parseTargets`, merge in `generateDataFile`
- `packages/gen-gen/test/generator.test.ts`: Add fixture tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)