### PR TITLE
T12: Strip project-specific options from API/CLI

### DIFF
--- a/.changeset/t12-strip-api-options.md
+++ b/.changeset/t12-strip-api-options.md
@@ -1,0 +1,5 @@
+---
+"gen-gen": major
+---
+
+Remove project-specific options from API/CLI; all project config now lives in the data-gen file

--- a/packages/gen-gen/src/cli-core.ts
+++ b/packages/gen-gen/src/cli-core.ts
@@ -1,11 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import {pathToFileURL} from "node:url";
 import {
   generateDataFile,
-  type FakerStrategyHook,
   type GenerateResult,
-  type PropertyPolicy,
 } from "./generator.js";
 
 export interface CliOptions {
@@ -14,15 +11,7 @@ export interface CliOptions {
   check: boolean;
   dryRun: boolean;
   failOnWarn: boolean;
-  optionalProperties: PropertyPolicy["optionalProperties"];
-  indexSignatures: PropertyPolicy["indexSignatures"];
-  fakerStrategyModule?: string;
-  fakerStrategy?: FakerStrategyHook;
   watch: boolean;
-  deepMerge: boolean;
-  include: string[];
-  exclude: string[];
-  fakerOverrides: Record<string, string>;
 }
 
 interface WatchHandle {
@@ -36,19 +25,12 @@ interface WatchDeps {
     cwd?: string;
     write: boolean;
     failOnWarn: boolean;
-    propertyPolicy: Partial<PropertyPolicy>;
-    fakerStrategy?: FakerStrategyHook;
-    deepMerge: boolean;
-    include: string[];
-    exclude: string[];
-    fakerOverrides: Record<string, string>;
   }): Promise<GenerateResult>;
   log(message: string): void;
   warn(message: string): void;
   error(message: string): void;
   setTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
   clearTimer(timer: ReturnType<typeof setTimeout>): void;
-  resolveFakerStrategy?(options: CliOptions): Promise<FakerStrategyHook | undefined>;
 }
 
 const defaultWatchDeps: WatchDeps = {
@@ -80,13 +62,7 @@ export function parseArgs(args: string[]): CliOptions {
     check: false,
     dryRun: false,
     failOnWarn: false,
-    optionalProperties: "include",
-    indexSignatures: "ignore",
     watch: false,
-    deepMerge: true,
-    include: [],
-    exclude: [],
-    fakerOverrides: {},
   };
 
   for (let i = 0; i < args.length; i += 1) {
@@ -119,62 +95,8 @@ export function parseArgs(args: string[]): CliOptions {
       continue;
     }
 
-    if (arg === "--optional-properties") {
-      const value = args[i + 1];
-      if (value !== "include" && value !== "omit") {
-        throw new Error("Expected --optional-properties to be one of: include, omit.");
-      }
-      options.optionalProperties = value;
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--index-signatures") {
-      const value = args[i + 1];
-      if (value !== "ignore" && value !== "warn") {
-        throw new Error("Expected --index-signatures to be one of: ignore, warn.");
-      }
-      options.indexSignatures = value;
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--faker-strategy") {
-      const value = args[i + 1];
-      if (!value) {
-        throw new Error("Expected a module path after --faker-strategy.");
-      }
-      options.fakerStrategyModule = value;
-      i += 1;
-      continue;
-    }
-
     if (arg === "--watch" || arg === "-w") {
       options.watch = true;
-      continue;
-    }
-
-    if (arg === "--deep-merge") {
-      options.deepMerge = true;
-      continue;
-    }
-
-    if (arg === "--include") {
-      options.include.push(...parseListArg(args[i + 1]));
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--exclude") {
-      options.exclude.push(...parseListArg(args[i + 1]));
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--faker-override") {
-      const {key, expression} = parseOverrideArg(args[i + 1]);
-      options.fakerOverrides[key] = expression;
-      i += 1;
       continue;
     }
 
@@ -196,17 +118,7 @@ Options:
       --check         Exit 1 if generated section is out of date
       --dry-run       Print resulting file content to stdout
       --fail-on-warn  Exit with error if generation emits warnings
-      --optional-properties <include|omit>
-                     Include or omit optional properties in generated base objects
-      --index-signatures <ignore|warn>
-                     Ignore or warn when index signatures are not materialized
-      --faker-strategy <path>
-                     Module path exporting faker strategy function (default export or named \`fakerStrategy\`)
   -w, --watch         Regenerate on file changes
-      --deep-merge    Deep merge overrides instead of shallow spread
-      --include       Comma-separated generator/type filters to include
-      --exclude       Comma-separated generator/type filters to exclude
-      --faker-override  key=expression override for faker output
   -h, --help          Show this help message
 `);
 }
@@ -256,10 +168,6 @@ export function createWatchModeRuntime(
 
   const syncWatchers = (files: string[]): void => {
     const next = new Set(files.map((file) => path.resolve(file)));
-    if (options.fakerStrategyModule) {
-      const baseCwd = options.cwd ?? process.cwd();
-      next.add(path.resolve(baseCwd, options.fakerStrategyModule));
-    }
 
     for (const existingFile of [...watchers.keys()]) {
       if (!next.has(existingFile)) {
@@ -290,21 +198,11 @@ export function createWatchModeRuntime(
     runCount += 1;
     const startedAt = Date.now();
     try {
-      const fakerStrategy = deps.resolveFakerStrategy ? await deps.resolveFakerStrategy(options) : options.fakerStrategy;
       const result = await deps.generate({
         input: options.input,
         cwd: options.cwd,
         write: true,
         failOnWarn: options.failOnWarn,
-        propertyPolicy: {
-          optionalProperties: options.optionalProperties,
-          indexSignatures: options.indexSignatures,
-        },
-        fakerStrategy,
-        deepMerge: options.deepMerge,
-        include: options.include,
-        exclude: options.exclude,
-        fakerOverrides: options.fakerOverrides,
       });
 
       for (const warning of result.warnings) {
@@ -340,12 +238,7 @@ export function createWatchModeRuntime(
 }
 
 export async function runWatchMode(options: CliOptions): Promise<void> {
-  const runtime = createWatchModeRuntime(options, {
-    ...defaultWatchDeps,
-    async resolveFakerStrategy(currentOptions) {
-      return loadFakerStrategyFromModule(currentOptions, true);
-    },
-  });
+  const runtime = createWatchModeRuntime(options, defaultWatchDeps);
 
   process.on("SIGINT", () => {
     runtime.closeWatchers();
@@ -381,22 +274,11 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
     return;
   }
 
-  const fakerStrategy = await loadFakerStrategyFromModule(options, false);
-
   const result = await generateDataFile({
     input: options.input,
     cwd: options.cwd,
     write: !options.dryRun && !options.check,
     failOnWarn: options.failOnWarn,
-    propertyPolicy: {
-      optionalProperties: options.optionalProperties,
-      indexSignatures: options.indexSignatures,
-    },
-    fakerStrategy,
-    deepMerge: options.deepMerge,
-    include: options.include,
-    exclude: options.exclude,
-    fakerOverrides: options.fakerOverrides,
   });
 
   for (const warning of result.warnings) {
@@ -421,57 +303,4 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
 
   const verb = result.changed ? "Generated" : "No changes for";
   console.log(`[gen-gen] ${verb} ${path.relative(process.cwd(), result.inputPath)}`);
-}
-
-function parseListArg(raw: string | undefined): string[] {
-  if (!raw) {
-    throw new Error("Expected a comma-separated value after list argument.");
-  }
-
-  return raw
-    .split(",")
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0);
-}
-
-function parseOverrideArg(raw: string | undefined): { key: string; expression: string } {
-  if (!raw) {
-    throw new Error("Expected key=expression after --faker-override.");
-  }
-
-  const separatorIndex = raw.indexOf("=");
-  if (separatorIndex <= 0) {
-    throw new Error("Expected --faker-override in the format key=expression.");
-  }
-
-  const key = raw.slice(0, separatorIndex).trim();
-  const expression = raw.slice(separatorIndex + 1).trim();
-  if (!key || !expression) {
-    throw new Error("Expected non-empty key and expression for --faker-override.");
-  }
-
-  return {key, expression};
-}
-
-async function loadFakerStrategyFromModule(
-  options: CliOptions,
-  cacheBust: boolean,
-): Promise<FakerStrategyHook | undefined> {
-  if (!options.fakerStrategyModule) {
-    return options.fakerStrategy;
-  }
-
-  const baseCwd = options.cwd ?? process.cwd();
-  const modulePath = path.resolve(baseCwd, options.fakerStrategyModule);
-  const moduleUrl = pathToFileURL(modulePath).href;
-  const imported = await import(cacheBust ? `${moduleUrl}?t=${Date.now()}` : moduleUrl);
-  const candidate = (imported.default ?? imported.fakerStrategy) as unknown;
-  if (typeof candidate !== "function") {
-    throw new Error(
-      `Invalid faker strategy module: ${options.fakerStrategyModule}. ` +
-        "Expected a default export or named export `fakerStrategy` function.",
-    );
-  }
-
-  return candidate as FakerStrategyHook;
 }

--- a/packages/gen-gen/src/generator.ts
+++ b/packages/gen-gen/src/generator.ts
@@ -7,12 +7,6 @@ export interface GenerateOptions {
   cwd?: string;
   write?: boolean;
   failOnWarn?: boolean;
-  propertyPolicy?: Partial<PropertyPolicy>;
-  deepMerge?: boolean;
-  include?: string[];
-  exclude?: string[];
-  fakerOverrides?: Record<string, FakerOverrideInput>;
-  fakerStrategy?: FakerStrategyHook;
 }
 
 export type FakerOverrideInput = string | ((faker: typeof import("@faker-js/faker").faker) => unknown);
@@ -96,18 +90,11 @@ export async function generateDataFile(options: GenerateOptions = {}): Promise<G
   const write = options.write ?? true;
 
   const original = await fs.readFile(inputPath, "utf8");
-  const parsed = parseTargets(inputPath, {
-    include: options.include ?? [],
-    exclude: options.exclude ?? [],
-    fakerOverrides: options.fakerOverrides ?? {},
-  });
+  const parsed = parseTargets(inputPath);
   const fileConfig = parsed.genGenConfig;
-  const mergedDeepMerge = options.deepMerge ?? fileConfig.deepMerge ?? true;
-  const mergedPropertyPolicy = resolvePropertyPolicy({
-    ...fileConfig,
-    ...options.propertyPolicy,
-  });
-  const fakerStrategy = options.fakerStrategy ?? parsed.fakerStrategy;
+  const mergedDeepMerge = fileConfig.deepMerge ?? true;
+  const mergedPropertyPolicy = resolvePropertyPolicy(fileConfig);
+  const fakerStrategy = parsed.fakerStrategy;
   const emitted = emitFunctions(
     parsed.targets,
     parsed.checker,
@@ -156,11 +143,6 @@ function resolvePropertyPolicy(policy: Partial<PropertyPolicy> | undefined): Pro
 
 function parseTargets(
   inputPath: string,
-  filterOptions: {
-    include: string[];
-    exclude: string[];
-    fakerOverrides: Record<string, FakerOverrideInput>;
-  },
 ): {
   sourceFile: ts.SourceFile;
   checker: ts.TypeChecker;
@@ -222,14 +204,11 @@ function parseTargets(
   for (const [key, value] of Object.entries(inFileFakerOverrides)) {
     fakerOverrides.set(normalizeFilterKey(key), value);
   }
-  for (const [key, value] of Object.entries(filterOptions.fakerOverrides)) {
-    fakerOverrides.set(normalizeFilterKey(key), toFakerOverrideSpec(value, key));
-  }
 
   const uniqueTargets = dedupeTargets(targets);
   const filterResult = applyTargetFilters(uniqueTargets, {
-    include: mergeFilters(filterOptions.include, inFileInclude),
-    exclude: mergeFilters(filterOptions.exclude, inFileExclude),
+    include: inFileInclude,
+    exclude: inFileExclude,
   });
   warnings.push(...collectUnmatchedFilterWarnings(filterResult));
 
@@ -576,16 +555,6 @@ function extractFunctionOverrideSpec(
   }
 
   return null;
-}
-
-function mergeFilters(...groups: string[][]): string[] {
-  const merged = new Set<string>();
-  for (const group of groups) {
-    for (const value of group) {
-      merged.add(value);
-    }
-  }
-  return [...merged];
 }
 
 function applyTargetFilters(

--- a/packages/gen-gen/src/vite-plugin.ts
+++ b/packages/gen-gen/src/vite-plugin.ts
@@ -1,21 +1,12 @@
 import path from "node:path";
 import {
   generateDataFile,
-  type FakerOverrideInput,
-  type FakerStrategyHook,
   type GenerateResult,
-  type PropertyPolicy,
 } from "./generator.js";
 
 export interface GenGenPluginOptions {
   input?: string;
   failOnWarn?: boolean;
-  propertyPolicy?: Partial<PropertyPolicy>;
-  deepMerge?: boolean;
-  include?: string[];
-  exclude?: string[];
-  fakerOverrides?: Record<string, FakerOverrideInput>;
-  fakerStrategy?: FakerStrategyHook;
 }
 
 interface ViteLikePluginContext {
@@ -37,12 +28,6 @@ interface PluginDeps {
     cwd?: string;
     write?: boolean;
     failOnWarn?: boolean;
-    propertyPolicy?: Partial<PropertyPolicy>;
-    deepMerge?: boolean;
-    include?: string[];
-    exclude?: string[];
-    fakerOverrides?: Record<string, FakerOverrideInput>;
-    fakerStrategy?: FakerStrategyHook;
   }): Promise<GenerateResult>;
   warn(message: string): void;
   error(message: string, error: unknown): void;
@@ -73,12 +58,6 @@ export function createGenGenPlugin(options: GenGenPluginOptions = {}, deps: Plug
       cwd: root,
       write,
       failOnWarn: options.failOnWarn,
-      propertyPolicy: options.propertyPolicy,
-      deepMerge: options.deepMerge,
-      include: options.include,
-      exclude: options.exclude,
-      fakerOverrides: options.fakerOverrides,
-      fakerStrategy: options.fakerStrategy,
     });
 
     watchedFiles.clear();

--- a/packages/gen-gen/test/cli-core.test.ts
+++ b/packages/gen-gen/test/cli-core.test.ts
@@ -3,17 +3,31 @@ import {describe, expect, test} from "bun:test";
 import {parseArgs} from "../src/cli-core.js";
 
 describe("cli-core parseArgs", () => {
-  test("parses --faker-strategy module path", () => {
-    const options = parseArgs(["--input", "example/basic/data-gen.ts", "--faker-strategy", "./strategy.ts"]);
-    expect(options.input).toBe("example/basic/data-gen.ts");
-    expect(options.fakerStrategyModule).toBe("./strategy.ts");
-  });
-
-  test("throws when --faker-strategy path is missing", () => {
-    expect(() => parseArgs(["--faker-strategy"])).toThrow("Expected a module path after --faker-strategy.");
+  test("throws for removed --preset flag", () => {
+    expect(() => parseArgs(["--preset", "common"])).toThrow("Unknown argument: --preset");
   });
 
   test("throws for unknown --watch-diagnostics flag", () => {
     expect(() => parseArgs(["--watch", "--watch-diagnostics"])).toThrow("Unknown argument: --watch-diagnostics");
+  });
+
+  test("throws for removed --faker-strategy flag", () => {
+    expect(() => parseArgs(["--faker-strategy", "./strategy.ts"])).toThrow("Unknown argument: --faker-strategy");
+  });
+
+  test("throws for removed --deep-merge flag", () => {
+    expect(() => parseArgs(["--deep-merge"])).toThrow("Unknown argument: --deep-merge");
+  });
+
+  test("throws for removed --include flag", () => {
+    expect(() => parseArgs(["--include", "A,B"])).toThrow("Unknown argument: --include");
+  });
+
+  test("throws for removed --exclude flag", () => {
+    expect(() => parseArgs(["--exclude", "C"])).toThrow("Unknown argument: --exclude");
+  });
+
+  test("throws for removed --faker-override flag", () => {
+    expect(() => parseArgs(["--faker-override", "key=value"])).toThrow("Unknown argument: --faker-override");
   });
 });

--- a/packages/gen-gen/test/cli-watch.test.ts
+++ b/packages/gen-gen/test/cli-watch.test.ts
@@ -13,13 +13,7 @@ function baseOptions(): CliOptions {
     check: false,
     dryRun: false,
     failOnWarn: false,
-    optionalProperties: "include",
-    indexSignatures: "ignore",
     watch: true,
-    deepMerge: false,
-    include: [],
-    exclude: [],
-    fakerOverrides: {},
   };
 }
 
@@ -163,41 +157,6 @@ describe("watch mode runtime", () => {
     runtime.closeWatchers();
   });
 
-  test("watches faker strategy module file in watch mode", async () => {
-    const watchedFiles = new Set<string>();
-    const runtime = createWatchModeRuntime(
-      {
-        ...baseOptions(),
-        cwd: "/tmp/project",
-        fakerStrategyModule: "./strategy.ts",
-      },
-      {
-        watch(file, listener): WatchHandle {
-          watchedFiles.add(path.resolve(file));
-          return {
-            close() {},
-          };
-        },
-        async generate() {
-          return createResult("/tmp/data-gen.ts", ["/tmp/project/example.ts"]);
-        },
-        log() {},
-        warn() {},
-        error() {},
-        setTimer(callback, delayMs) {
-          return setTimeout(callback, delayMs);
-        },
-        clearTimer(timer) {
-          clearTimeout(timer);
-        },
-      },
-    );
-
-    await runtime.run();
-    expect(watchedFiles.has(path.resolve("/tmp/project/example.ts"))).toBeTrue();
-    expect(watchedFiles.has(path.resolve("/tmp/project/strategy.ts"))).toBeTrue();
-    runtime.closeWatchers();
-  });
 
   test("emits watch diagnostics logs when enabled", async () => {
     const logs: string[] = [];

--- a/packages/gen-gen/test/generator.test.ts
+++ b/packages/gen-gen/test/generator.test.ts
@@ -117,13 +117,17 @@ export type Deep = {
       "data-gen.ts": `
 import type { Deep } from "./types";
 
+const GenGenConfig = {
+  deepMerge: true,
+} as const;
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({cwd, write: true, deepMerge: true});
+    const result = await generateDataFile({cwd, write: true});
     expect(result.content).toContain("function __genGenMergeDeep<T>(base: T, overrides: Partial<T> | undefined): T {");
     expect(result.content).toContain("return __genGenMergeDeep(base, resolvedOverrides);");
 
@@ -315,7 +319,7 @@ import type { UnionWrapper } from "./types";
     expect(result.content).toContain("orderId: faker.number.int({ min: 1, max: 1000 })");
   });
 
-  test("applies include/exclude filters from GenerateOptions", async () => {
+  test("applies include/exclude filters from IncludeGenerators/ExcludeGenerators in data-gen file", async () => {
     const cwd = await createFixture({
       "types.ts": `
 export type A = { a: string };
@@ -325,18 +329,16 @@ export type C = { c: boolean };
       "data-gen.ts": `
 import type { A, B, C } from "./types";
 
+type IncludeGenerators = [A, B];
+type ExcludeGenerators = [B];
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      include: ["A", "generateB"],
-      exclude: ["B"],
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     expect(result.content).toContain("export function generateA(");
     expect(result.content).not.toContain("export function generateB(");
@@ -407,7 +409,7 @@ const FakerOverrides = {
     expect(result.content).not.toContain("export function generateUserId(");
   });
 
-  test("applies FakerOverrides passed via GenerateOptions", async () => {
+  test("applies FakerOverrides from data-gen file", async () => {
     const cwd = await createFixture({
       "types.ts": `
 export type User = {
@@ -418,26 +420,24 @@ export type User = {
       "data-gen.ts": `
 import type { User } from "./types";
 
+const FakerOverrides = {
+  name: () => faker.person.firstName(),
+  age: 42,
+} as const;
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      fakerOverrides: {
-        name: (faker) => faker.person.firstName(),
-        age: "42",
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
-    expect(result.content).toContain("name: ((faker) => faker.person.firstName())(faker)");
+    expect(result.content).toContain("name: faker.person.firstName()");
     expect(result.content).toContain("age: 42");
   });
 
-  test("applies fakerStrategy when no direct FakerOverrides match", async () => {
+  test("applies FakerStrategy from data-gen file when no direct FakerOverrides match", async () => {
     const cwd = await createFixture({
       "types.ts": `
 export type User = {
@@ -449,32 +449,30 @@ export type User = {
       "data-gen.ts": `
 import type { User } from "./types";
 
+const FakerStrategy = (context) => {
+  if (context.rootTypeText === "User" && context.path === "id") {
+    return { expression: "faker.string.uuid()", invokeMode: "raw" };
+  }
+  if (context.path === "email") {
+    return { expression: "faker.internet.email()", invokeMode: "raw" };
+  }
+  return undefined;
+};
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      fakerStrategy(context) {
-        if (context.rootTypeText === "User" && context.path === "id") {
-          return {expression: "faker.string.uuid()", invokeMode: "raw"};
-        }
-        if (context.path === "email") {
-          return (faker) => faker.internet.email();
-        }
-        return undefined;
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     expect(result.content).toContain("id: faker.string.uuid()");
-    expect(result.content).toContain("email: ((faker) => faker.internet.email())(faker)");
+    expect(result.content).toContain("email: faker.internet.email()");
     expect(result.content).toContain("age: faker.number.int({ min: 1, max: 1000 })");
   });
 
-  test("prioritizes FakerOverrides over fakerStrategy", async () => {
+  test("prioritizes FakerOverrides over FakerStrategy in data-gen file", async () => {
     const cwd = await createFixture({
       "types.ts": `
 export type User = {
@@ -485,25 +483,24 @@ export type User = {
       "data-gen.ts": `
 import type { User } from "./types";
 
+const FakerOverrides = {
+  "User.id": () => faker.string.alphanumeric(12),
+} as const;
+
+const FakerStrategy = (context) => {
+  if (context.path === "id") {
+    return { expression: "faker.string.uuid()", invokeMode: "raw" };
+  }
+  return undefined;
+};
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      fakerOverrides: {
-        "User.id": "faker.string.alphanumeric(12)",
-      },
-      fakerStrategy(context) {
-        if (context.path === "id") {
-          return {expression: "faker.string.uuid()", invokeMode: "raw"};
-        }
-        return undefined;
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     expect(result.content).toContain("id: faker.string.alphanumeric(12)");
     expect(result.content).not.toContain("id: faker.string.uuid()");
@@ -559,7 +556,7 @@ const FakerOverrides = {
     expect(result.content).toContain("email: faker.internet.email()");
   });
 
-  test("warns for unmatched include/exclude filters and unused faker overrides", async () => {
+  test("warns for unmatched include/exclude filters and unused faker overrides from data-gen file", async () => {
     const cwd = await createFixture({
       "types.ts": `
 export type User = {
@@ -569,21 +566,20 @@ export type User = {
       "data-gen.ts": `
 import type { User } from "./types";
 
+type IncludeGenerators = [User, MissingType];
+type ExcludeGenerators = [AlsoMissing];
+
+const FakerOverrides = {
+  "Missing.path": "() => faker.word.noun()",
+} as const;
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      include: ["User", "MissingType"],
-      exclude: ["AlsoMissing"],
-      fakerOverrides: {
-        "Missing.path": "() => faker.word.noun()",
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     expect(result.warnings).toContain("Unmatched include filters: MissingType");
     expect(result.warnings).toContain("Unmatched exclude filters: AlsoMissing");
@@ -602,19 +598,17 @@ export type User = {
       "data-gen.ts": `
 import type { User } from "./types";
 
+const FakerOverrides = {
+  "User.emial": "faker.internet.email()",
+} as const;
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      fakerOverrides: {
-        "User.emial": "faker.internet.email()",
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     const warning = result.warnings.find((w) => w.includes("User.emial"));
     expect(warning).toBeDefined();
@@ -633,20 +627,18 @@ export type User = {
       "data-gen.ts": `
 import type { User } from "./types";
 
+const FakerOverrides = {
+  "User.email": "faker.internet.email()",
+  "CompletelyUnrelated.xyzzy": "faker.word.noun()",
+} as const;
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      fakerOverrides: {
-        "User.email": "faker.internet.email()",
-        "CompletelyUnrelated.xyzzy": "faker.word.noun()",
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     const warning = result.warnings.find((w) => w.includes("CompletelyUnrelated.xyzzy"));
     expect(warning).toBeDefined();
@@ -661,6 +653,8 @@ export type User = { name: string };
       "data-gen.ts": `
 import type { User } from "./types";
 
+type IncludeGenerators = [MissingType];
+
 /**
  * Generated below - DO NOT EDIT
  */
@@ -672,7 +666,6 @@ import type { User } from "./types";
         cwd,
         write: false,
         failOnWarn: true,
-        include: ["MissingType"],
       }),
     ).rejects.toThrow("Generation failed due to warnings:");
   });
@@ -753,7 +746,7 @@ import type { User } from "./types";
     expect(result.content).not.toContain("locale: faker");
   });
 
-  test("omits optional properties when optionalProperties policy is omit", async () => {
+  test("omits optional properties when optionalProperties policy is omit via GenGenConfig", async () => {
     const cwd = await createFixture({
       "types.ts": `
 export type Account = {
@@ -764,25 +757,23 @@ export type Account = {
       "data-gen.ts": `
 import type { Account } from "./types";
 
+const GenGenConfig = {
+  optionalProperties: "omit",
+} as const;
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      propertyPolicy: {
-        optionalProperties: "omit",
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     expect(result.content).toContain("id: faker.word.noun()");
     expect(result.content).not.toContain("email:");
   });
 
-  test("emits warnings for index signatures by policy", async () => {
+  test("emits warnings for index signatures by policy via GenGenConfig", async () => {
     const cwd = await createFixture({
       "types.ts": `
 export type Config = {
@@ -795,19 +786,17 @@ export type Config = {
       "data-gen.ts": `
 import type { Config } from "./types";
 
+const GenGenConfig = {
+  indexSignatures: "warn",
+} as const;
+
 /**
  * Generated below - DO NOT EDIT
  */
 `,
     });
 
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      propertyPolicy: {
-        indexSignatures: "warn",
-      },
-    });
+    const result = await generateDataFile({cwd, write: false});
 
     expect(result.warnings).not.toContain("Readonly property included by policy at Config.id.");
     expect(result.warnings).toContain("Index signature (string) not materialized at Config.values.");
@@ -1151,45 +1140,6 @@ const FakerStrategy = (ctx) => {
     expect(result.content).toContain("age: faker.number.int({ min: 1, max: 1000 })");
   });
 
-  test("API-level fakerStrategy overrides file-level FakerStrategy", async () => {
-    const cwd = await createFixture({
-      "types.ts": `
-export type User = {
-  id: string;
-  email: string;
-};
-`,
-      "data-gen.ts": `
-import type { User } from "./types";
-
-const FakerStrategy = (ctx) => {
-  if (ctx.path === "id") {
-    return { expression: "faker.string.uuid()", invokeMode: "raw" };
-  }
-  return undefined;
-};
-
-/**
- * Generated below - DO NOT EDIT
- */
-`,
-    });
-
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      fakerStrategy(context) {
-        if (context.path === "id") {
-          return {expression: "faker.string.alphanumeric(12)", invokeMode: "raw"};
-        }
-        return undefined;
-      },
-    });
-
-    // API strategy wins: alphanumeric, not uuid
-    expect(result.content).toContain("id: faker.string.alphanumeric(12)");
-    expect(result.content).not.toContain("id: faker.string.uuid()");
-  });
 
   test("GenGenConfig in data-gen file sets optionalProperties to omit", async () => {
     const cwd = await createFixture({
@@ -1243,34 +1193,6 @@ const GenGenConfig = {
     expect(result.content).not.toContain("return __genGenMergeDeep(base, resolvedOverrides);");
   });
 
-  test("API-level options override GenGenConfig in data-gen file", async () => {
-    const cwd = await createFixture({
-      "types.ts": `
-export type Item = { id: number; name: string; description?: string };
-`,
-      "data-gen.ts": `
-import type { Item } from "./types";
-
-const GenGenConfig = {
-  optionalProperties: "omit",
-} as const;
-
-/**
- * Generated below - DO NOT EDIT
- */
-`,
-    });
-
-    // API-level override: include optional properties despite file config saying omit
-    const result = await generateDataFile({
-      cwd,
-      write: false,
-      propertyPolicy: {optionalProperties: "include"},
-    });
-
-    expect(result.content).toContain("export function generateItem(");
-    expect(result.content).toContain("description:");
-  });
 
   test("GenGenConfig deepMerge=true from file enables deep merge helper", async () => {
     const cwd = await createFixture({

--- a/packages/gen-gen/test/vite-plugin.test.ts
+++ b/packages/gen-gen/test/vite-plugin.test.ts
@@ -24,12 +24,6 @@ describe("vite plugin", () => {
       {
         input: "example/data-gen.ts",
         failOnWarn: true,
-        propertyPolicy: {
-          optionalProperties: "omit",
-          indexSignatures: "warn",
-        },
-        include: ["User"],
-        fakerStrategy: () => "faker.string.uuid()",
       },
       {
         async generate(options) {
@@ -56,12 +50,6 @@ describe("vite plugin", () => {
     expect(generatedOptions[0]?.cwd).toBe("/workspace/project");
     expect(generatedOptions[0]?.write).toBeTrue();
     expect(generatedOptions[0]?.failOnWarn).toBeTrue();
-    expect(generatedOptions[0]?.propertyPolicy).toEqual({
-      optionalProperties: "omit",
-      indexSignatures: "warn",
-    });
-    expect(generatedOptions[0]?.include).toEqual(["User"]);
-    expect(typeof generatedOptions[0]?.fakerStrategy).toBe("function");
   });
 
   test("configureServer regenerates and reloads only for watched changed files", async () => {


### PR DESCRIPTION
## Summary

- Removes `deepMerge`, `propertyPolicy`, `fakerStrategy`, `fakerOverrides`, `include`, `exclude` from `GenerateOptions`, `GenGenPluginOptions`, and `CliOptions`
- Removes corresponding CLI flags: `--optional-properties`, `--index-signatures`, `--faker-strategy`, `--deep-merge`, `--include`, `--exclude`, `--faker-override`
- Removes helper functions: `loadFakerStrategyFromModule`, `parseListArg`, `parseOverrideArg`, `mergeFilters`
- Updates all test fixtures to place config in data-gen file rather than passing via API
- Adds `major` changeset

## Why

After T10 (GenGenConfig in data-gen file) and T11 (FakerStrategy in data-gen file), all project-level config lives in the data-gen file. The API now only takes operational options: `input`, `cwd`, `write`, `failOnWarn`, `watch`, `check`, `dryRun`.

## Verification

- `bun run typecheck` ✅
- `bun test` ✅ 59/59 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)