### PR TITLE
Redesign website with brutalist aesthetic

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -23,6 +23,9 @@
       content="Generate Faker-powered TypeScript test factories from your project types with overrides, helper callbacks, and watch mode diagnostics."
     />
     <meta name="twitter:image" content="/og-gen-gen.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=JetBrains+Mono:wght@400;700&family=Space+Mono:wght@400;700&family=Instrument+Sans:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,900&family=DM+Mono:wght@400;500&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/website/src/components/code-block.tsx
+++ b/website/src/components/code-block.tsx
@@ -10,9 +10,9 @@ interface CodeBlockProps {
 
 export function CodeBlock({code, language, className}: CodeBlockProps) {
   return (
-    <Highlight code={code.trimEnd()} language={language} theme={themes.vsLight}>
+    <Highlight code={code.trimEnd()} language={language} theme={themes.vsDark}>
       {({className: highlightClassName, style, tokens, getLineProps, getTokenProps}) => (
-        <pre className={cn("overflow-auto rounded-md border p-3 text-sm", highlightClassName, className)} style={style}>
+        <pre className={cn("overflow-auto border-2 border-foreground bg-[#0a0a0a] p-4 text-sm", highlightClassName, className)} style={{...style, backgroundColor: "#0a0a0a"}}>
           {tokens.map((line, lineIndex) => {
             const lineProps = getLineProps({line});
             return (

--- a/website/src/components/docs-article.tsx
+++ b/website/src/components/docs-article.tsx
@@ -15,21 +15,21 @@ export function DocsArticle({title, summary, children}: DocsArticleProps) {
 
   return (
     <article className="space-y-6">
-      <header className="space-y-3 border-b pb-4">
+      <header className="space-y-3 border-b-[3px] border-foreground pb-4">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+          <h1 className="font-display text-2xl uppercase md:text-3xl">{title}</h1>
           {current ? (
             <a
               href={getEditUrl(current.sourcePath)}
               target="_blank"
               rel="noreferrer"
-              className="text-sm text-muted-foreground hover:text-foreground"
+              className="text-[10px] uppercase tracking-[0.1em] text-muted-foreground hover:text-foreground"
             >
               Edit on GitHub
             </a>
           ) : null}
         </div>
-        <p className="text-muted-foreground">{summary}</p>
+        <p className="text-xs text-muted-foreground">{summary}</p>
       </header>
 
       <div className="[&_pre]:max-w-full [&_pre]:w-full [&_pre]:overflow-x-auto [&_pre]:overflow-y-hidden min-w-0 space-y-6 text-sm leading-6">
@@ -37,20 +37,20 @@ export function DocsArticle({title, summary, children}: DocsArticleProps) {
       </div>
 
       {(previous || next) && (
-        <footer className="grid gap-3 border-t pt-4 sm:grid-cols-2">
+        <footer className="grid gap-0 border-t-[3px] border-foreground pt-4 sm:grid-cols-2">
           <div>
             {previous ? (
-              <Link to={previous.to} className="block rounded-md border bg-card p-3 hover:bg-muted/60">
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Previous</p>
-                <p className="font-medium">{previous.title}</p>
+              <Link to={previous.to} className="block border-2 border-foreground p-3 transition-colors hover:bg-foreground hover:text-background">
+                <p className="text-[10px] uppercase tracking-[0.1em] text-muted-foreground">Previous</p>
+                <p className="font-bold">{previous.title}</p>
               </Link>
             ) : null}
           </div>
           <div>
             {next ? (
-              <Link to={next.to} className="block rounded-md border bg-card p-3 text-right hover:bg-muted/60">
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Next</p>
-                <p className="font-medium">{next.title}</p>
+              <Link to={next.to} className="block border-2 border-l-0 border-foreground p-3 text-right transition-colors hover:bg-foreground hover:text-background max-sm:border-l-2 max-sm:border-t-0">
+                <p className="text-[10px] uppercase tracking-[0.1em] text-muted-foreground">Next</p>
+                <p className="font-bold">{next.title}</p>
               </Link>
             ) : null}
           </div>

--- a/website/src/components/ui/button.tsx
+++ b/website/src/components/ui/button.tsx
@@ -4,18 +4,18 @@ import {cva, type VariantProps} from "class-variance-authority";
 import {cn} from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center border-[3px] border-foreground text-xs font-bold uppercase tracking-[0.06em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:opacity-90",
-        secondary: "bg-secondary text-secondary-foreground hover:opacity-90",
-        ghost: "hover:bg-muted",
+        default: "bg-foreground text-background hover:bg-primary hover:border-primary",
+        secondary: "bg-background text-foreground hover:bg-foreground hover:text-background",
+        ghost: "border-transparent hover:bg-muted",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        default: "h-10 px-5 py-2",
+        sm: "h-9 px-4",
+        lg: "h-11 px-8",
       },
     },
     defaultVariants: {

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -3,20 +3,21 @@
 @tailwind utilities;
 
 :root {
-  --background: 40 20% 98%;
-  --foreground: 210 25% 12%;
+  --background: 0 0% 100%;
+  --foreground: 0 0% 4%;
   --card: 0 0% 100%;
-  --card-foreground: 210 25% 12%;
-  --primary: 203 89% 53%;
+  --card-foreground: 0 0% 4%;
+  --primary: 0 83% 59%;
   --primary-foreground: 0 0% 100%;
-  --secondary: 45 92% 52%;
-  --secondary-foreground: 210 25% 12%;
-  --muted: 210 18% 93%;
-  --muted-foreground: 210 14% 42%;
-  --border: 210 20% 86%;
-  --input: 210 20% 86%;
-  --ring: 203 89% 53%;
-  --radius: 0.75rem;
+  --secondary: 0 0% 96%;
+  --secondary-foreground: 0 0% 4%;
+  --muted: 0 0% 96%;
+  --muted-foreground: 0 0% 40%;
+  --border: 0 0% 4%;
+  --border-light: 0 0% 86%;
+  --input: 0 0% 86%;
+  --ring: 0 83% 59%;
+  --radius: 0px;
 }
 
 * {
@@ -27,18 +28,22 @@ body {
   margin: 0;
   min-height: 100vh;
   @apply bg-background text-foreground antialiased;
-  font-family: "IBM Plex Sans", "Avenir Next", Avenir, "Segoe UI", sans-serif;
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
 code,
 pre,
 textarea {
-  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
-.bg-grid {
-  background-image: radial-gradient(circle at 1px 1px, hsl(var(--border)) 1px, transparent 0);
-  background-size: 18px 18px;
+@keyframes ticker {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/website/src/routes/__root.tsx
+++ b/website/src/routes/__root.tsx
@@ -1,46 +1,58 @@
-import {Link, Outlet, createRootRoute} from "@tanstack/react-router";
+import {Link, Outlet, createRootRoute, useRouterState} from "@tanstack/react-router";
 import {TanStackRouterDevtools} from "@tanstack/react-router-devtools";
-
-const navLinkClass = "text-sm text-muted-foreground transition hover:text-foreground";
 
 export const Route = createRootRoute({
   component: RootLayout,
 });
 
+const navLinkClass = "flex h-full items-center border-l-[3px] border-foreground px-5 text-xs uppercase tracking-[0.08em] text-foreground no-underline transition-colors hover:bg-foreground hover:text-background";
+
 function RootLayout() {
+  const routerState = useRouterState();
+  const isHome = routerState.location.pathname === "/";
+
   return (
-    <div className="min-h-screen bg-grid">
-      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-card focus:px-3 focus:py-2">
+    <div className="min-h-screen">
+      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:bg-card focus:px-3 focus:py-2">
         Skip to content
       </a>
-      <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-3 md:px-6">
-          <Link to="/" className="text-lg font-semibold tracking-tight">
-            gen-gen
+
+      {/* NAV */}
+      <header className="fixed top-0 left-0 right-0 z-40 flex h-[52px] items-center justify-between border-b-[3px] border-foreground bg-background">
+        <Link to="/" className="pl-8 font-display text-xl text-foreground no-underline">
+          gen-gen
+        </Link>
+        <nav aria-label="Primary" className="flex h-full">
+          <Link to="/docs" className={navLinkClass}>
+            Docs
           </Link>
-          <nav aria-label="Primary" className="flex items-center gap-4 md:gap-6">
-            <Link to="/docs" className={navLinkClass} activeProps={{className: "text-foreground"}}>
-              Docs
-            </Link>
-            <Link to="/playground" className={navLinkClass} activeProps={{className: "text-foreground"}}>
-              Playground
-            </Link>
-            <a className={navLinkClass} href="https://www.npmjs.com/package/gen-gen" target="_blank" rel="noreferrer">
-              npm
-            </a>
-            <a className={navLinkClass} href="https://github.com/justinturner/gen-gen" target="_blank" rel="noreferrer">
-              GitHub
-            </a>
-          </nav>
-        </div>
+          <Link to="/playground" className={navLinkClass}>
+            Playground
+          </Link>
+          <a className={navLinkClass} href="https://www.npmjs.com/package/gen-gen" target="_blank" rel="noreferrer">
+            npm
+          </a>
+          <a className={navLinkClass} href="https://github.com/justinturner/gen-gen" target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+        </nav>
       </header>
-      <main id="main-content" className="mx-auto w-full max-w-6xl px-4 py-8 md:px-6 md:py-12">
+
+      {/* MAIN */}
+      <main id="main-content" className={isHome ? "mt-[52px]" : "mx-auto mt-[52px] w-full max-w-6xl px-6 py-10 md:px-10 md:py-14"}>
         <Outlet />
       </main>
-      <footer className="border-t bg-card/40">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-4 py-6 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between md:px-6">
-          <p>Type-safe factory generation for test suites.</p>
-          <p>Built with TypeScript, Faker, TanStack Router, and Tailwind.</p>
+
+      {/* FOOTER */}
+      <footer className="flex items-center justify-between border-t-[3px] border-foreground px-10 py-4 text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+        <span>gen-gen</span>
+        <div className="flex gap-5">
+          <a href="https://github.com/justinturner/gen-gen" target="_blank" rel="noreferrer" className="text-foreground no-underline hover:underline hover:[text-decoration-thickness:2px]">
+            GitHub
+          </a>
+          <a href="https://www.npmjs.com/package/gen-gen" target="_blank" rel="noreferrer" className="text-foreground no-underline hover:underline hover:[text-decoration-thickness:2px]">
+            npm
+          </a>
         </div>
       </footer>
       <TanStackRouterDevtools position="bottom-right" />

--- a/website/src/routes/docs.tsx
+++ b/website/src/routes/docs.tsx
@@ -24,21 +24,21 @@ function DocsLayout() {
   }, [query]);
 
   return (
-    <div className="grid gap-6 md:grid-cols-[280px_1fr]">
-      <aside className="h-fit space-y-3 rounded-lg border bg-card p-3 text-sm md:sticky md:top-6">
+    <div className="grid gap-0 md:grid-cols-[260px_1fr]">
+      <aside className="h-fit space-y-3 border-b-[3px] border-r-0 border-foreground p-4 text-sm md:sticky md:top-[52px] md:border-b-0 md:border-r-[3px]">
         <div>
-          <div className="font-medium">Documentation</div>
-          <p className="text-xs text-muted-foreground">MVP reference for CLI, API, plugin, and behavior details.</p>
+          <div className="font-display text-sm uppercase">Documentation</div>
+          <p className="mt-1 text-[10px] uppercase tracking-[0.1em] text-muted-foreground">CLI, API, plugin, and behavior reference.</p>
         </div>
 
         <input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Filter docs"
-          className="w-full rounded-md border bg-background px-2 py-1.5 text-sm outline-none ring-primary focus:ring-1"
+          className="w-full border-2 border-foreground bg-background px-2 py-1.5 text-sm outline-none focus:border-primary"
         />
 
-        <nav className="flex max-h-[60vh] flex-col gap-1 overflow-auto pr-1">
+        <nav className="flex max-h-[60vh] flex-col gap-0.5 overflow-auto pr-1">
           {filtered.map((item) => {
             const active =
               location.pathname === item.to ||
@@ -48,21 +48,21 @@ function DocsLayout() {
               <Link
                 key={item.to}
                 to={item.to}
-                className={`rounded px-2 py-1.5 ${
+                className={`px-2 py-1.5 text-xs transition-colors ${
                   active
-                    ? "bg-muted font-medium text-foreground"
-                    : "bg-card text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                    ? "bg-foreground font-bold text-background"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
                 }`}
               >
                 {item.title}
               </Link>
             );
           })}
-          {filtered.length === 0 ? <p className="px-2 py-1 text-xs text-muted-foreground">No matching docs pages.</p> : null}
+          {filtered.length === 0 ? <p className="px-2 py-1 text-[10px] text-muted-foreground">No matching docs.</p> : null}
         </nav>
       </aside>
 
-      <section className="min-w-0 rounded-lg border bg-card p-5">
+      <section className="min-w-0 p-6 md:p-8">
         <Outlet />
       </section>
     </div>

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -1,174 +1,208 @@
-import {Link, createFileRoute} from "@tanstack/react-router";
-
-import {Button} from "@/components/ui/button";
+import {createFileRoute} from "@tanstack/react-router";
+import {useCallback, useState} from "react";
 
 export const Route = createFileRoute("/")({
   component: HomePage,
 });
 
-const features = [
-  {
-    title: "Nested Helpers",
-    body: "Override deeply nested branches with generated helper callbacks instead of brittle object replacement.",
-  },
-  {
-    title: "Deep Merge Option",
-    body: "Switch from shallow override spread to recursive merge when you need concise nested test overrides.",
-  },
-  {
-    title: "Faker Overrides",
-    body: "Provide custom faker expressions by path or type key to match your domain formats.",
-  },
-  {
-    title: "Strategy + Presets",
-    body: "Apply preset mappings and policy controls for optional, readonly, and index-signature behavior.",
-  },
-  {
-    title: "Include/Exclude Filters",
-    body: "Generate only the factories you need for a test target, package, or feature slice.",
-  },
-  {
-    title: "Watch Diagnostics",
-    body: "Track regeneration triggers and run metrics during watch mode for faster feedback loops.",
-  },
-];
+/* ── Random data generators (lightweight, no faker dependency) ── */
 
-const snippets = [
-  {
-    title: "CLI",
-    code: "gen-gen --input data-gen.ts --watch --watch-diagnostics",
-  },
-  {
-    title: "API",
-    code: "const output = generateFactories({ sourcePath: 'data-gen.ts', deepMerge: true });",
-  },
-  {
-    title: "Vite Plugin",
-    code: "plugins: [genGenPlugin({ input: 'data-gen.ts', deepMerge: true })]",
-  },
-];
+function randomId() {
+  return Math.random().toString(36).slice(2, 10);
+}
 
-const examples = [
-  {title: "Basics", description: "Simple interface generation and overrides", link: "/docs/getting-started"},
-  {title: "CLI", description: "Flags, watch mode, diagnostics", link: "/docs/cli"},
-  {title: "Docs Overview", description: "Capabilities and workflow", link: "/docs"},
-];
+function randomEmail(name: string) {
+  const domains = ["test.io", "example.com", "mock.dev", "fake.net"];
+  const slug = name.toLowerCase().replace(/\s+/g, ".") || "user";
+  return `${slug}@${domains[Math.floor(Math.random() * domains.length)]}`;
+}
+
+function randomAge() {
+  return 18 + Math.floor(Math.random() * 50);
+}
+
+function randomColour() {
+  const colours = ["orange", "teal", "crimson", "slate", "indigo", "coral", "mint", "amber", "violet", "rust"];
+  return colours[Math.floor(Math.random() * colours.length)];
+}
+
+function generateUserData(nameOverride: string) {
+  return {
+    id: `"${randomId()}"`,
+    name: `"${nameOverride}"`,
+    email: `"${randomEmail(nameOverride)}"`,
+    age: randomAge(),
+    favouriteColour: `"${randomColour()}"`,
+  };
+}
+
+/* ── Guided demo component ── */
+
+function GuidedDemo() {
+  const [nameOverride, setNameOverride] = useState("John Gen-Gen");
+  const [userData, setUserData] = useState(() => generateUserData("John Gen-Gen"));
+
+  const regenerate = useCallback(() => {
+    setUserData(generateUserData(nameOverride));
+  }, [nameOverride]);
+
+  function handleNameChange(value: string) {
+    setNameOverride(value);
+    setUserData((prev) => ({
+      ...prev,
+      name: `"${value}"`,
+      email: `"${randomEmail(value)}"`,
+    }));
+  }
+
+  return (
+    <div className="flex h-full flex-col justify-center gap-6 p-8 md:gap-8 md:p-12">
+      {/* STEP 1 — Import types */}
+      <div>
+        <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-[#555]">
+          01 — Feed your types to gen-gen
+        </div>
+        <pre className="border-2 border-[#222] bg-[#111] p-4 text-[12px] leading-[1.8]">
+          <code>
+            <span className="text-[#666]">import type</span>{" "}
+            <span className="text-[#e0e0e0]">{"{"}</span>
+            <span className="text-[#ccc]">User</span>
+            <span className="text-[#e0e0e0]">{"}"}</span>{" "}
+            <span className="text-[#666]">from</span>{" "}
+            <span className="text-[#888]">"./user"</span>
+            <span className="text-[#555]">;</span>
+          </code>
+        </pre>
+      </div>
+
+      {/* STEP 2 — Generate data */}
+      <div>
+        <div className="mb-3 text-[10px] uppercase tracking-[0.2em] text-[#555]">
+          02 — Override what matters
+        </div>
+        <pre className="border-2 border-[#222] bg-[#111] p-4 text-[12px] leading-[1.8]">
+          <code>
+            <span className="text-[#666]">const</span>{" "}
+            <span className="text-[#ccc]">user</span>{" "}
+            <span className="text-[#666]">=</span>{" "}
+            <span className="text-[#e0e0e0]">makeUser</span>
+            <span className="text-[#888]">({"{"}</span>
+            {"\n"}
+            {"  "}
+            <span className="text-[#888]">name:</span>{" "}
+            <span className="text-primary">"</span>
+            <input
+              type="text"
+              value={nameOverride}
+              onChange={(e) => handleNameChange(e.target.value)}
+              spellCheck={false}
+              className="inline w-auto border-b border-dashed border-primary bg-transparent text-center text-[12px] text-primary outline-none"
+              style={{width: `${Math.max(nameOverride.length, 1)}ch`}}
+              aria-label="Name override"
+            />
+            <span className="text-primary">"</span>
+            {"\n"}
+            <span className="text-[#888]">{"})"}</span>
+            <span className="text-[#555]">;</span>
+          </code>
+        </pre>
+      </div>
+
+      {/* STEP 3 — Output */}
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <span className="text-[10px] uppercase tracking-[0.2em] text-[#555]">
+            03 — The rest is randomized
+          </span>
+          <button
+            onClick={regenerate}
+            className="border-2 border-[#333] bg-transparent px-3 py-1 text-[10px] uppercase tracking-[0.12em] text-[#888] transition-colors hover:border-primary hover:text-primary"
+          >
+            Regenerate
+          </button>
+        </div>
+        <pre className="border-2 border-[#222] bg-[#111] p-4 text-[12px] leading-[1.8]">
+          <code>
+            <span className="text-[#555]">{"// user"}</span>
+            {"\n"}
+            <span className="text-[#888]">{"{"}</span>
+            {"\n"}
+            {"  "}
+            <span className="text-[#666]">id:</span>{" "}
+            <span className="text-[#888]">{userData.id}</span>
+            <span className="text-[#555]">,</span>
+            {"\n"}
+            {"  "}
+            <span className="text-[#666]">name:</span>{" "}
+            <span className="text-primary">{userData.name}</span>
+            <span className="text-[#555]">,</span>
+            {"        "}
+            <span className="text-[#444]">{"// ← your override"}</span>
+            {"\n"}
+            {"  "}
+            <span className="text-[#666]">email:</span>{" "}
+            <span className="text-[#888]">{userData.email}</span>
+            <span className="text-[#555]">,</span>
+            {"\n"}
+            {"  "}
+            <span className="text-[#666]">age:</span>{" "}
+            <span className="text-[#888]">{userData.age}</span>
+            <span className="text-[#555]">,</span>
+            {"\n"}
+            {"  "}
+            <span className="text-[#666]">favouriteColour:</span>{" "}
+            <span className="text-[#888]">{userData.favouriteColour}</span>
+            {"\n"}
+            <span className="text-[#888]">{"}"}</span>
+          </code>
+        </pre>
+      </div>
+    </div>
+  );
+}
 
 function HomePage() {
   return (
-    <div className="space-y-16 md:space-y-20">
-      <section className="relative overflow-hidden rounded-3xl border bg-card p-8 shadow-sm md:p-12">
-        <div className="pointer-events-none absolute -right-24 -top-24 h-64 w-64 rounded-full bg-primary/20 blur-3xl" aria-hidden="true" />
-        <div className="pointer-events-none absolute -bottom-20 -left-16 h-52 w-52 rounded-full bg-secondary/30 blur-3xl" aria-hidden="true" />
-        <div className="relative space-y-6">
-          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">Type-Safe Test Data Generation</p>
-          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight md:text-6xl">
-            Generate realistic test factories directly from TypeScript types.
+    <div className="grid h-[calc(100vh-52px)] grid-cols-1 md:grid-cols-[1fr_3px_1fr]">
+      {/* LEFT — Name, why, install */}
+      <div className="flex flex-col justify-between p-10 md:p-12">
+        <div />
+
+        <div>
+          <h1 className="font-display text-[clamp(64px,10vw,140px)] uppercase leading-[0.88] tracking-[-0.04em]">
+            gen<span className="text-primary">-</span>gen
           </h1>
-          <p className="max-w-2xl text-base text-muted-foreground md:text-lg">
-            `gen-gen` turns your existing type model into composable factory functions so tests stay deterministic, readable,
-            and fast to evolve.
+          <p className="mt-6 max-w-[420px] text-[13px] leading-[1.8] text-muted-foreground">
+            Test data by hand doesn't scale. Hard-coded fixtures leak.
+            Shared globals hide bugs. gen-gen reads your TypeScript types
+            and generates factory functions — override what matters,
+            randomize the rest.
           </p>
-          <div className="flex flex-wrap gap-3">
-            <Link to="/docs/getting-started">
-              <Button size="lg">Start with Docs</Button>
-            </Link>
-            <Link to="/playground">
-              <Button size="lg" variant="secondary">
-                Open Playground
-              </Button>
-            </Link>
-            <a href="https://github.com/justinturner/gen-gen" target="_blank" rel="noreferrer" className="inline-flex">
-              <Button size="lg" variant="ghost">
-                View GitHub
-              </Button>
-            </a>
-          </div>
         </div>
-      </section>
 
-      <section aria-labelledby="features-title" className="space-y-5">
-        <h2 id="features-title" className="text-2xl font-semibold tracking-tight md:text-3xl">
-          Built for modern test workflows
-        </h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {features.map((feature) => (
-            <article key={feature.title} className="rounded-xl border bg-card p-5">
-              <h3 className="text-lg font-medium">{feature.title}</h3>
-              <p className="mt-2 text-sm text-muted-foreground">{feature.body}</p>
-            </article>
+        <div className="flex items-center gap-3 border-[3px] border-foreground bg-secondary px-5 py-3">
+          <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground">Install</span>
+          <code className="text-[13px]"><span className="text-primary">$</span> npm install gen-gen --save-dev</code>
+        </div>
+      </div>
+
+      {/* VERTICAL DIVIDER — ticker */}
+      <div className="hidden overflow-hidden bg-primary md:flex" aria-hidden="true">
+        <div className="flex animate-[ticker_20s_linear_infinite] flex-col whitespace-nowrap [writing-mode:vertical-lr]">
+          {[...Array(2)].map((_, i) => (
+            <span key={i} className="flex flex-col">
+              {["Types in", "Factories out", "Faker powered", "Override what matters", "Randomize the rest", "Zero config", "Type-safe"].map((text) => (
+                <span key={text} className="px-0 py-4 text-[10px] font-bold uppercase tracking-[0.18em] text-background">{text}</span>
+              ))}
+            </span>
           ))}
         </div>
-      </section>
+      </div>
 
-      <section aria-labelledby="how-title" className="grid gap-4 md:grid-cols-3">
-        <h2 id="how-title" className="md:col-span-3 text-2xl font-semibold tracking-tight md:text-3xl">
-          How it works
-        </h2>
-        <article className="rounded-xl border bg-card p-5">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">1. Import Types</p>
-          <p className="mt-2 text-sm">Point `gen-gen` at a source file that references your domain interfaces and aliases.</p>
-        </article>
-        <article className="rounded-xl border bg-card p-5">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">2. Run Generator</p>
-          <p className="mt-2 text-sm">Generate factories from CLI, script, or Vite plugin and keep them up to date in watch mode.</p>
-        </article>
-        <article className="rounded-xl border bg-card p-5">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">3. Override in Tests</p>
-          <p className="mt-2 text-sm">Customize output with partial overrides or nested helper callbacks for scenario-specific fixtures.</p>
-        </article>
-      </section>
-
-      <section aria-labelledby="quickstart-title" className="space-y-5">
-        <h2 id="quickstart-title" className="text-2xl font-semibold tracking-tight md:text-3xl">
-          Quickstart snippets
-        </h2>
-        <div className="grid gap-4 md:grid-cols-3">
-          {snippets.map((snippet) => (
-            <article key={snippet.title} className="rounded-xl border bg-card p-5">
-              <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">{snippet.title}</h3>
-              <pre className="mt-3 overflow-auto rounded-md bg-muted p-3 text-xs">
-                <code>{snippet.code}</code>
-              </pre>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section aria-labelledby="examples-title" className="space-y-5">
-        <h2 id="examples-title" className="text-2xl font-semibold tracking-tight md:text-3xl">
-          Explore examples
-        </h2>
-        <div className="grid gap-4 md:grid-cols-3">
-          {examples.map((example) => (
-            <article key={example.title} className="flex flex-col rounded-xl border bg-card p-5">
-              <h3 className="text-lg font-medium">{example.title}</h3>
-              <p className="mt-2 flex-1 text-sm text-muted-foreground">{example.description}</p>
-              <Link to={example.link} className="mt-4 inline-flex text-sm font-medium text-primary hover:opacity-80">
-                Open page
-              </Link>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section aria-labelledby="positioning-title" className="rounded-3xl border bg-card p-8 md:p-10">
-        <h2 id="positioning-title" className="text-2xl font-semibold tracking-tight md:text-3xl">
-          Why teams use this for tests
-        </h2>
-        <p className="mt-4 max-w-3xl text-sm text-muted-foreground md:text-base">
-          Generated factories reduce fixture drift by deriving values from your source-of-truth types. You keep expressive test
-          setup while removing repetitive handwritten builders and inconsistent mock payloads.
-        </p>
-        <div className="mt-6 flex flex-wrap gap-3">
-          <a href="https://www.npmjs.com/package/gen-gen" target="_blank" rel="noreferrer" className="inline-flex">
-            <Button>Install from npm</Button>
-          </a>
-          <Link to="/docs" className="inline-flex">
-            <Button variant="secondary">Read full docs</Button>
-          </Link>
-        </div>
-      </section>
+      {/* RIGHT — Guided demo */}
+      <div className="flex flex-col border-t-[3px] border-foreground bg-[#0a0a0a] text-[#e0e0e0] md:border-t-0">
+        <GuidedDemo />
+      </div>
     </div>
   );
 }

--- a/website/src/routes/playground.tsx
+++ b/website/src/routes/playground.tsx
@@ -58,22 +58,22 @@ function PlaygroundPage() {
   return (
     <section aria-labelledby="playground-title" className="space-y-6">
       <header className="space-y-2">
-        <h1 id="playground-title" className="text-3xl font-semibold tracking-tight md:text-4xl">
+        <h1 id="playground-title" className="font-display text-2xl uppercase md:text-3xl">
           Type Playground
         </h1>
-        <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
+        <p className="max-w-3xl text-xs text-muted-foreground">
           Paste TypeScript types and generate a starter factory instantly. MVP supports in-file declarations only.
         </p>
       </header>
 
-      <div className="flex flex-wrap items-center gap-3 rounded-xl border bg-card p-3">
+      <div className="flex flex-wrap items-center gap-3 border-[3px] border-foreground bg-secondary p-3">
         <Button onClick={handleGenerate}>Generate</Button>
-        <label className="inline-flex cursor-pointer items-center gap-2 text-sm">
+        <label className="inline-flex cursor-pointer items-center gap-2 text-xs uppercase tracking-[0.06em]">
           <input
             type="checkbox"
             checked={autoGenerate}
             onChange={(event) => setAutoGenerate(event.target.checked)}
-            className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
+            className="h-4 w-4 border-foreground accent-primary"
           />
           Auto-generate
         </label>
@@ -82,34 +82,34 @@ function PlaygroundPage() {
         </Button>
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-2">
+      <div className="grid gap-0 lg:grid-cols-2">
         <section className="space-y-2">
-          <h2 className="text-sm font-medium">Input TypeScript</h2>
+          <h2 className="text-[10px] font-bold uppercase tracking-[0.15em]">Input TypeScript</h2>
           <textarea
             value={input}
             onChange={(event) => setInput(event.target.value)}
             spellCheck={false}
-            className="h-[460px] w-full rounded-xl border bg-card p-4 font-mono text-sm leading-relaxed outline-none ring-ring transition focus:ring-2"
+            className="h-[460px] w-full border-[3px] border-foreground bg-[#0a0a0a] p-4 font-mono text-sm leading-relaxed text-[#e0e0e0] outline-none focus:border-primary"
             aria-label="TypeScript input"
           />
         </section>
 
         <section className="space-y-2">
-          <h2 className="text-sm font-medium">Generated Output</h2>
+          <h2 className="text-[10px] font-bold uppercase tracking-[0.15em]">Generated Output</h2>
           <textarea
             value={currentOutput}
             readOnly
             spellCheck={false}
-            className="h-[460px] w-full rounded-xl border bg-card p-4 font-mono text-sm leading-relaxed outline-none"
+            className="h-[460px] w-full border-[3px] border-foreground bg-[#0a0a0a] p-4 font-mono text-sm leading-relaxed text-[#e0e0e0] outline-none lg:border-l-0"
             aria-label="Generated output"
           />
         </section>
       </div>
 
       {currentErrors.length > 0 ? (
-        <section className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-900" aria-live="polite">
-          <h2 className="font-medium">Diagnostics</h2>
-          <ul className="mt-2 list-disc space-y-1 pl-5">
+        <section className="border-[3px] border-primary bg-primary/5 p-4 text-sm text-foreground" aria-live="polite">
+          <h2 className="font-display text-sm uppercase">Diagnostics</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-xs">
             {currentErrors.map((error) => (
               <li key={error}>{error}</li>
             ))}

--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -5,8 +5,13 @@ const config: Config = {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
     extend: {
+      fontFamily: {
+        display: ["'Archivo Black'", "sans-serif"],
+        mono: ["'JetBrains Mono'", "SFMono-Regular", "Menlo", "Consolas", "monospace"],
+      },
       colors: {
         border: "hsl(var(--border))",
+        "border-light": "hsl(var(--border-light))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
@@ -30,8 +35,8 @@ const config: Config = {
       },
       borderRadius: {
         lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+        md: "var(--radius)",
+        sm: "var(--radius)",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Replace the soft/rounded design system with a brutalist aesthetic: monospace typography (JetBrains Mono + Archivo Black), 0px border radius, 3px black borders, black/white/red (#ff2d2d) palette
- Simplify landing page to a single viewport: "why" copy + install command on the left, guided interactive demo on the right showing the override-what-matters workflow
- Update all pages (docs, playground) to match the new design system: dark code blocks, inverted active states, thick structural borders, uppercase display headings
- Vertical red ticker divider between hero halves

## Changed files

- `index.html` — Google Fonts (Archivo Black, JetBrains Mono)
- `index.css` — New design tokens (black/white/red palette, 0px radius, monospace body font)
- `tailwind.config.ts` — Added font-display/font-mono families, border-light token, 0px radii
- `__root.tsx` — Brutalist nav (cell-style border links), full-width landing, contained inner pages
- `index.tsx` — Single-viewport hero with guided demo (editable name override, regenerate button)
- `docs.tsx` — Sidebar with thick borders, inverted active state
- `docs-article.tsx` — Display font headers, thick border dividers, inverted prev/next nav
- `code-block.tsx` — Dark theme (vsDark), dark background
- `button.tsx` — 3px borders, uppercase, inverted color variants
- `playground.tsx` — Dark textareas, uppercase labels, bordered toolbar

## Test plan

- [ ] Verify landing page renders as single viewport with guided demo
- [ ] Verify name input in demo updates output in real-time
- [ ] Verify regenerate button re-rolls random fields
- [ ] Verify docs pages render with new styling (sidebar, article, code blocks)
- [ ] Verify playground page renders with dark textareas
- [ ] Verify nav links work across all pages
- [ ] Check responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)