### PR TITLE
Add test-with-gen-gen skill for Claude Code

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "gen-gen",
+  "description": "Type-safe test data generation for TypeScript. Guides agents to use gen-gen factory functions when writing tests.",
+  "version": "1.0.0",
+  "author": {
+    "name": "gen-gen"
+  }
+}

--- a/skills/test-with-gen-gen/REFERENCE.md
+++ b/skills/test-with-gen-gen/REFERENCE.md
@@ -1,0 +1,133 @@
+# gen-gen Reference
+
+## data-gen.ts file structure
+
+```ts
+import type { User, Order } from "./types";
+import { faker } from "@faker-js/faker";
+
+// Optional: concrete instantiations of generic types
+type ConcreteGenerics = [APIResponse<User>];
+
+// Optional: filter which types get generators
+type IncludeGenerators = [User, Order];
+type ExcludeGenerators = [InternalType];
+
+// Optional: customize faker values per field
+const FakerOverrides: TypedFakerOverrides = {
+  "User.id": () => faker.string.uuid(),
+  email: () => faker.internet.email(),
+};
+
+// Optional: global fallback for property patterns
+const FakerStrategy = (context: FakerStrategyContext): FakerStrategyResult | undefined => {
+  if (context.propertyName === "id" && context.typeText === "string") {
+    return { expression: "faker.string.uuid()", invokeMode: "raw" };
+  }
+  return undefined;
+};
+
+// Optional: control generation behavior
+const GenGenConfig: GenGenConfigOptions = {
+  deepMerge: true,
+  optionalProperties: "include",
+  indexSignatures: "ignore",
+};
+
+/**
+ * Generated below - DO NOT EDIT
+ */
+// ... generated code appears here
+```
+
+## FakerOverrides
+
+Customize the faker expression for specific properties. Matching priority (first wins):
+
+1. `TypeName.property.nested.path` (e.g., `User.profile.settings.theme`)
+2. `property.nested.path` (e.g., `profile.settings.theme`)
+3. `propertyName` (e.g., `theme`)
+4. Declared type text (e.g., `"string"`)
+5. Type alias name (e.g., `UserId`)
+
+Value formats:
+- `() => faker.string.uuid()` — arrow function, inlined
+- `(faker) => faker.string.uuid()` — called with faker instance
+- `faker.string.uuid` — property access, auto-invoked
+- `"42"` — string, inserted as raw code
+
+## FakerStrategy
+
+Project-wide fallback function. Receives context about each property:
+
+- `rootTypeText` — name of root type being generated
+- `propertyPath` — array from root to this property
+- `propertyName` — leaf property name
+- `typeText` — resolved TypeScript type
+- `aliasTypeText` — type alias name if it exists
+
+Return `{ expression, invokeMode }` or `undefined` to use defaults.
+
+## GenGenConfig options
+
+| Option | Default | Description |
+|---|---|---|
+| `deepMerge` | `true` | Recursively merge overrides into base objects |
+| `optionalProperties` | `"include"` | `"include"` generates values, `"omit"` skips them |
+| `indexSignatures` | `"ignore"` | `"ignore"` skips them, `"warn"` emits warnings |
+
+## Type filtering
+
+```ts
+// Only generate for these types
+type IncludeGenerators = [User, Order];
+
+// Generate for all imported types except these
+type ExcludeGenerators = [InternalType];
+```
+
+## Generic types
+
+Declare concrete instantiations:
+
+```ts
+type ConcreteGenerics = [APIResponse<User>, APIResponse<Order>];
+```
+
+Generates `generateUserAPIResponse()`, `generateOrderAPIResponse()`.
+
+## Ignoring types or properties
+
+```ts
+/** @gen-gen-ignore */
+export type Secret = { token: string };
+
+export type Account = {
+  id: string;
+  /** @gen-gen-ignore */
+  internalMeta: { ... };
+};
+```
+
+## CLI flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--input <path>` | `-i` | Path to data-gen file (default: `data-gen.ts`) |
+| `--watch` | `-w` | Watch and regenerate on changes |
+| `--check` | | Exit 1 if output is stale (for CI) |
+| `--dry-run` | | Print to stdout without writing |
+| `--fail-on-warn` | | Exit with error on warnings |
+| `--cwd <path>` | | Working directory |
+
+## Vite plugin
+
+```ts
+import { genGenPlugin } from "gen-gen/vite";
+
+export default defineConfig({
+  plugins: [genGenPlugin({ input: "src/data-gen.ts" })],
+});
+```
+
+Automatically regenerates during `vite dev` and `vite build`.

--- a/skills/test-with-gen-gen/SKILL.md
+++ b/skills/test-with-gen-gen/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: test-with-gen-gen
+description: Generate type-safe test data using gen-gen factory functions. Use when writing tests that need test data, creating test fixtures, or setting up mock data for TypeScript projects that have gen-gen installed.
+---
+
+# Writing Tests with gen-gen
+
+Use gen-gen generators whenever a test needs structured data. Never hand-write full object literals — use `generateX()` functions instead. Override only what matters to the test; let gen-gen randomize the rest.
+
+```ts
+// GOOD — intent is clear: this test is about admin role behavior
+const admin = generateUser({ role: "admin" });
+
+// BAD — every field spelled out, test intent buried
+const admin: User = { id: "1", name: "Alice", email: "a@b.com", role: "admin", avatar: "...", ... };
+```
+
+## Workflow
+
+### 1. Check if a generator exists
+
+Look at the project's `data-gen.ts` (usually `src/data-gen.ts`). Functions appear after the `Generated below - DO NOT EDIT` marker. Each imported type gets a `generateX()` function.
+
+### 2. Add a missing type
+
+Add a **type-only import** to the top of `data-gen.ts`, then regenerate:
+
+```ts
+import type { User, Order, NewType } from "./types";
+```
+
+### 3. Regenerate
+
+```bash
+npx gen-gen --input src/data-gen.ts
+```
+
+If the project uses the Vite plugin or `--watch` mode, generation happens automatically. Check `vite.config.ts` or `package.json` scripts before running manually.
+
+### 4. Use in tests
+
+```ts
+import { generateOrder } from "../data-gen";
+
+test("applies discount to orders over $100", () => {
+  const order = generateOrder({ total: 150 });
+  expect(applyDiscount(order)).toBe(true);
+});
+```
+
+## Overrides
+
+**Partial object:**
+```ts
+const user = generateUser({ role: "admin", email: "test@example.com" });
+```
+
+**Nested (deep merge, enabled by default):**
+```ts
+const draft = generateCheckoutDraft({
+  shipping: { address: { city: "Portland" } },
+});
+// shipping.address.line1, postalCode, etc. remain random
+```
+
+**Callback helpers** for nested objects and array items:
+```ts
+const draft = generateCheckoutDraft((helpers) => ({
+  shipping: { address: helpers.generateAddress({ city: "Portland" }) },
+  items: helpers.generateItemsItems(3),
+}));
+```
+
+**Pinning union/enum values:**
+```ts
+const errorResponse = generateApiResponse({ status: "error" });
+const activeTicket = generateTicket({ status: Status.Active });
+```
+
+## Anti-patterns to avoid
+
+| Don't | Do |
+|---|---|
+| Hand-write full object literals | `generateX({ relevantField: value })` |
+| Share fixtures across tests | Generate fresh data per test |
+| Ignore TS errors on test data | Use generators — always type-safe |
+| Spread into generator output | Pass overrides to the generator |
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Add a type | Add `import type { X }` to `data-gen.ts` |
+| Regenerate | `npx gen-gen --input src/data-gen.ts` |
+| Preview output | `npx gen-gen --dry-run --input src/data-gen.ts` |
+| Check freshness (CI) | `npx gen-gen --check --input src/data-gen.ts` |
+
+See [REFERENCE.md](REFERENCE.md) for FakerOverrides, FakerStrategy, GenGenConfig, and CLI flags.


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`test-with-gen-gen`) that guides agents to use gen-gen factory functions when writing tests
- Includes plugin manifest (`.claude-plugin/plugin.json`) for distribution via skills.sh
- SKILL.md covers the core workflow (check generators, add types, regenerate, use in tests) and anti-patterns to avoid
- REFERENCE.md covers advanced config: FakerOverrides, FakerStrategy, GenGenConfig, CLI flags, Vite plugin

## Test plan
- [ ] Install skill locally and verify it triggers when writing tests that need test data
- [ ] Verify SKILL.md renders correctly and stays under 100 lines
- [ ] Verify REFERENCE.md links work from SKILL.md
- [ ] Test plugin install flow via `claude --plugin-dir .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)