### PR TITLE
Prepare @trnr/gen-gen for initial npm publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": ["gen-gen"]
+  "updateInternalDependencies": "patch"
 }

--- a/.changeset/t12-strip-api-options.md
+++ b/.changeset/t12-strip-api-options.md
@@ -1,5 +1,0 @@
----
-"gen-gen": major
----
-
-Remove project-specific options from API/CLI; all project config now lives in the data-gen file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Build
         run: bun run build
 
-      # - name: Generate examples
-      #   run: bun run gen:example
-
   changeset:
     name: Changeset Required
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Pre-publish build
         run: bun run build
 
-      - name: Pre-publish example generation
-        run: bun run gen:example
-
       - name: Configure npm auth
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "website"
   ],
   "scripts": {
-    "dev": "bun run --filter gen-gen dev & bun run --filter gen-gen-website dev",
-    "build": "bun run --filter gen-gen build",
-    "typecheck": "bun run --filter gen-gen typecheck",
-    "test": "bun run --filter gen-gen test",
-    "check": "bun run --filter gen-gen typecheck && bun run --filter gen-gen test && bun run --filter gen-gen-website typecheck && bun run --filter gen-gen-website build",
+    "dev": "bun run --filter @trnr/gen-gen dev & bun run --filter gen-gen-website dev",
+    "build": "bun run --filter @trnr/gen-gen build",
+    "typecheck": "bun run --filter @trnr/gen-gen typecheck",
+    "test": "bun run --filter @trnr/gen-gen test",
+    "check": "bun run --filter @trnr/gen-gen typecheck && bun run --filter @trnr/gen-gen test && bun run --filter gen-gen-website typecheck && bun run --filter gen-gen-website build",
     "web:dev": "bun run --filter gen-gen-website dev",
     "web:build": "bun run --filter gen-gen-website build",
     "web:typecheck": "bun run --filter gen-gen-website typecheck",

--- a/packages/gen-gen/package.json
+++ b/packages/gen-gen/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gen-gen",
+  "name": "@trnr/gen-gen",
   "version": "0.1.0",
   "description": "Generate Faker-based test data builders from imported TypeScript types.",
   "type": "module",
@@ -22,6 +22,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary
- Scope package as `@trnr/gen-gen` with `publishConfig.access: "public"` for npm publishing
- Remove changeset ignore and stale changefile to enable the release workflow
- Remove nonexistent `gen:example` step from CI and release workflows
- Fix workspace filter references in root `package.json`

## Test plan
- [ ] Verify `bun install` resolves workspace packages correctly
- [ ] Verify CI passes (typecheck, test, build)
- [ ] Verify changeset status check works on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)