### PR TITLE
fix: use `bun run test` in release workflow to match CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: bun run typecheck
 
       - name: Pre-publish test
-        run: bun test
+        run: bun run test
 
       - name: Pre-publish build
         run: bun run build


### PR DESCRIPTION
## Summary
- The Release workflow used `bun test` (Bun's built-in runner from repo root) while CI uses `bun run test` (package.json script filtered to the package directory)
- `bun test` from the repo root creates temp fixture dirs at the root level where Bun's module resolution can't find `@faker-js/faker` through symlinked `node_modules`
- Fixes the 3 failing tests: `deepMerge mode preserves...`, `supports array-item helpers...`, `supports plural array-item helpers...`

## Test plan
- [ ] Merge to main and verify Release workflow passes all 56 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)