### PR TITLE
Fix 404 on page refresh for Vercel SPA routing

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` with a catch-all rewrite rule so all routes serve `index.html`
- Fixes 404 errors when refreshing any page other than the home page

## Test plan
- [ ] Deploy preview and verify refreshing non-root pages (e.g. `/docs`, `/api`) no longer returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)